### PR TITLE
[FEAT] 자체 로그인 및 토큰 재발급

### DIFF
--- a/src/main/java/com/example/quizley/config/SecurityConfig.java
+++ b/src/main/java/com/example/quizley/config/SecurityConfig.java
@@ -88,6 +88,7 @@ public class SecurityConfig {
                         // 인증 없이 접근 가능한 공개 API
                         .requestMatchers("/api/users/signup").permitAll()
                         .requestMatchers("/api/users/login").permitAll()
+                        .requestMatchers("/api/users/refresh").permitAll()
 
                         // 어드민 보호
                         .requestMatchers("/api/admin/**").denyAll()

--- a/src/main/java/com/example/quizley/controller/UserController.java
+++ b/src/main/java/com/example/quizley/controller/UserController.java
@@ -1,17 +1,26 @@
 package com.example.quizley.controller;
 
 import com.example.quizley.common.ApiSuccess;
+import com.example.quizley.config.jwt.JwtProvider;
+import com.example.quizley.dto.users.LoginFormDto;
 import com.example.quizley.dto.users.SignupFormDto;
 import com.example.quizley.entity.users.Users;
 import com.example.quizley.service.UsersService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 
 // 회원가입, 로그인 로직
@@ -22,6 +31,7 @@ public class UserController {
 
     private final UsersService usersService;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     // 회원가입
     @PostMapping("/signup")
@@ -32,5 +42,80 @@ public class UserController {
 
         // 컨벤션: 데이터 없을 때 status + message
         return ResponseEntity.status(201).body(new ApiSuccess(201, "성공적으로 처리되었습니다."));
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Valid @RequestBody LoginFormDto loginFormDto) {
+
+        UserDetails user;
+
+        // id로 유저 조회
+        try {
+            user = usersService.loadUserByUsername(loginFormDto.getUserId());
+        } catch (UsernameNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS");
+        }
+
+        // 입력된 비번과 저장된 해시 비교
+        if (!passwordEncoder.matches(loginFormDto.getPassword(), user.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS");
+        }
+
+        // JWT 발급
+        String accessToken  = jwtProvider.createAccessToken(user.getUsername());
+        String refreshToken = jwtProvider.createRefreshToken(user.getUsername());
+
+        // refresh 토큰 DB에 저장
+        usersService.updateRefreshToken(user.getUsername(), refreshToken);
+
+        // JSON 응답 데이터
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", 200);
+        body.put("message", "로그인 성공");
+        body.put("accessToken", accessToken);
+        body.put("refreshToken", refreshToken);
+
+        // JSON 응답 생성 (accessToken 발급)
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .body(body);
+
+    }
+
+    // Access + Refresh Token 재발급
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshToken(@RequestBody Map<String, String> request) {
+        // 프론트가 보낸 refreshToken 값 가져오기
+        String refreshToken = request.get("refreshToken");
+
+        // refreshToken 누락 체크
+        if (refreshToken == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "REFRESH_TOKEN_REQUIRED");
+        }
+
+        // refreshToken 내부에서 userId 추출
+        String userId = jwtProvider.getSubject(refreshToken);
+
+        // DB에 저장된 refreshToken과 일치하는지 검증
+        if (!usersService.validateRefreshToken(userId, refreshToken)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN");
+        }
+
+        // 새 Access Token + 새 Refresh Token 발급
+        String newAccessToken = jwtProvider.createAccessToken(userId);
+        String newRefreshToken = jwtProvider.createRefreshToken(userId);
+
+        // DB에 새 refreshToken 갱신 (기존 것은 무효화)
+        usersService.updateRefreshToken(userId, newRefreshToken);
+
+        // 응답 JSON
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", 200);
+        body.put("message", "토큰 재발급 완료");
+        body.put("accessToken", newAccessToken);
+        body.put("refreshToken", newRefreshToken);
+
+        return ResponseEntity.ok(body);
     }
 }

--- a/src/main/java/com/example/quizley/dto/users/LoginFormDto.java
+++ b/src/main/java/com/example/quizley/dto/users/LoginFormDto.java
@@ -1,0 +1,16 @@
+package com.example.quizley.dto.users;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+
+// 프론트가 입력한 로그인 데이터
+@Getter @Setter
+public class LoginFormDto {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String userId;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/example/quizley/entity/users/Users.java
+++ b/src/main/java/com/example/quizley/entity/users/Users.java
@@ -43,6 +43,9 @@ public class Users {
     @Column(nullable = false)
     private Integer level; // 레벨
 
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt; // 회원가입 일자

--- a/src/main/java/com/example/quizley/repository/UsersRepository.java
+++ b/src/main/java/com/example/quizley/repository/UsersRepository.java
@@ -2,10 +2,14 @@ package com.example.quizley.repository;
 
 import com.example.quizley.entity.users.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 
 // 유저 레포지토리
 public interface UsersRepository extends JpaRepository<Users, Long> {
     // 유저 아이디 중복 검사
     boolean existsById(String id);
+
+    // 유저 아이디로 해당 유저 찾기
+    Optional<Users> findById(String id);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,7 +30,8 @@ server.error.include-message=never
 server.error.include-binding-errors=never
 
 jwt.secret=change-this-to-a-very-long-random-secret-at-least-256-bits
-jwt.access-exp-millis=86400000
+jwt.access-exp-millis=900000
+jwt.refresh-exp-millis=604800000
 
 app.upload-dir=uploads
 


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 자체 로그인
- refresh 토큰 재발급

---

## 🔗 포스트맨 이미지
<img width="590" height="771" alt="image" src="https://github.com/user-attachments/assets/05f83e4f-08fb-4903-8944-d4d90eadf904" />
<img width="601" height="779" alt="image" src="https://github.com/user-attachments/assets/cdb1d2bd-6008-46cc-8155-66c234294158" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->
- 기존 1일이었던 access Token 유효 시간을 15분으로 단축
- refresh 토큰 로직 추가
- DB refresh token 칼럼 추가 및 Users 엔티티 수정

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- 노션 ERD 및 데이터베이스 페이지에 refresh token 칼럼을 추가한 최종 SQL문을 작성하였습니다.