### PR TITLE
[FEAT]커뮤니티 첫 화면 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.mockito:mockito-core:5.10.0'
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
+
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 
 def querydslDir = "$buildDir/generated/sources/annotationProcessor/java"

--- a/src/main/java/com/example/quizley/controller/CommunityController.java
+++ b/src/main/java/com/example/quizley/controller/CommunityController.java
@@ -1,0 +1,53 @@
+package com.example.quizley.controller;
+
+import com.example.quizley.dto.community.CommunityHomeResponse;
+import com.example.quizley.dto.community.QuizListDto;
+import com.example.quizley.service.CommunityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/community")
+@RequiredArgsConstructor
+public class CommunityController {
+    private final CommunityService communityService;
+
+    //커뮤니티 홈 화면 조회 GET /api/community/home?date=2025-10-05
+    @GetMapping("/home")
+    public ResponseEntity<Map<String, Object>> getCommunityHome(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+
+        CommunityHomeResponse response = communityService.getCommunityHome(date);
+
+        //응답 JSON 생성
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", 200);
+        body.put("data", response);
+        body.put("message", "커뮤니티 홈 화면 조회 성공");
+        return ResponseEntity.ok(body);
+    }
+
+    //게시글 목록 조회(최신순/인기순)
+    @GetMapping("/quizzes")
+    public ResponseEntity<Map<String, Object>> getQuizList(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(defaultValue = "latest") String sortBy) {
+
+        List<QuizListDto> quizzes = communityService.getQuizList(date, sortBy);
+
+        //응답 JSON 생성
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", 200);
+        body.put("message", "게시글 목록 조회 성공");
+        body.put("data", quizzes);
+
+        return ResponseEntity.ok(body);
+    }
+}

--- a/src/main/java/com/example/quizley/dto/community/CommunityHomeResponse.java
+++ b/src/main/java/com/example/quizley/dto/community/CommunityHomeResponse.java
@@ -1,0 +1,19 @@
+package com.example.quizley.dto.community;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+import java.util.Map;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommunityHomeResponse {
+    private LocalDate date;
+    private TodayQuizDto todayQuiz;
+    private Map<String, List<HotQuizDto>> hotQuizzesByCategory;
+}

--- a/src/main/java/com/example/quizley/dto/community/HotQuizDto.java
+++ b/src/main/java/com/example/quizley/dto/community/HotQuizDto.java
@@ -1,0 +1,20 @@
+package com.example.quizley.dto.community;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HotQuizDto {
+    private Long quizId;
+    private String content;
+    private String category;
+    private Long likeCount;
+    private Long commentCount;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/quizley/dto/community/QuizListDto.java
+++ b/src/main/java/com/example/quizley/dto/community/QuizListDto.java
@@ -1,0 +1,20 @@
+package com.example.quizley.dto.community;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.Builder;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizListDto {
+    private Long quizId;
+    private String content;
+    private String category;
+    private Long likeCount;
+    private Long commentCount;
+    private LocalDate publishedDate;
+}

--- a/src/main/java/com/example/quizley/dto/community/TodayQuizDto.java
+++ b/src/main/java/com/example/quizley/dto/community/TodayQuizDto.java
@@ -1,0 +1,17 @@
+package com.example.quizley.dto.community;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.Builder;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TodayQuizDto {
+    private Long quizId;
+    private String content;
+    private String category;
+    private LocalDate publishDate;
+}

--- a/src/main/java/com/example/quizley/repository/QuizRepository.java
+++ b/src/main/java/com/example/quizley/repository/QuizRepository.java
@@ -2,9 +2,13 @@ package com.example.quizley.repository;
 
 import com.example.quizley.domain.Category;
 import com.example.quizley.domain.QuizType;
+import com.example.quizley.domain.Origin;
 import com.example.quizley.entity.quiz.Quiz;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 // 퀴즈 레포지토리
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
@@ -13,6 +17,36 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
             QuizType type,
             LocalDate publishedDate,
             Category category
+    );
+
+    //커뮤니티 기능: 오늘의 질문 조회
+    Optional<Quiz> findByPublishedDateAndOrigin(
+            LocalDate publishedDate,
+            Origin origin
+    );
+
+    //특정 날짜의 모든 질문 조회(최신순)
+    List<Quiz> findByPublishedDateOrderByCreatedAtDesc(LocalDate publishedDate);
+
+    //특정 날짜, 특정 카테고리의 질문 조회(최신순, 상위 N개)
+    List<Quiz> findByPublishedDateAndCategoryOrderByCreatedAtDesc(
+            LocalDate publishedDate,
+            Category category,
+            Pageable pageable
+    );
+
+    //Origin 포함한 조회
+    List<Quiz> findByPublishedDateAndOriginAndCategoryOrderByCreatedAtDesc(
+            LocalDate publishedDate,
+            Origin origin,
+            Category category,
+            Pageable pageable
+    );
+
+    //특정 날짜, 특정 Origin의 질문 조회 (최신순)
+    List<Quiz> findByPublishedDateAndOriginOrderByCreatedAtDesc(
+            LocalDate publishedDate,
+            Origin origin
     );
 }
 

--- a/src/main/java/com/example/quizley/service/CommunityService.java
+++ b/src/main/java/com/example/quizley/service/CommunityService.java
@@ -1,0 +1,127 @@
+package com.example.quizley.service;
+
+import com.example.quizley.domain.Category;
+import com.example.quizley.domain.Origin;
+import com.example.quizley.dto.community.CommunityHomeResponse;
+import com.example.quizley.dto.community.HotQuizDto;
+import com.example.quizley.dto.community.QuizListDto;
+import com.example.quizley.dto.community.TodayQuizDto;
+import com.example.quizley.entity.quiz.Quiz;
+import com.example.quizley.repository.QuizRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommunityService {
+    private final QuizRepository quizRepository;
+
+    //커뮤니티 홈 화면 조회
+    public CommunityHomeResponse getCommunityHome(LocalDate date) {
+        //오늘의 질문 조회
+        Quiz todayQuiz = quizRepository.findByPublishedDateAndOrigin(date, Origin.SYSTEM)
+                .orElseThrow(()-> new RuntimeException("오늘의 질문이 없습니다."));
+
+        //카테고리별로 HOT 인기글 3개씩 조회
+        Map<String, List<HotQuizDto>> hotQuizzesByCategory = new LinkedHashMap<>();
+
+        //모든 카테고리 순회
+        for (Category category : Category.values()) {
+            List<Quiz> hotQuizzes = quizRepository
+                    .findByPublishedDateAndOriginAndCategoryOrderByCreatedAtDesc(
+                            date,
+                            Origin.USER,
+                            category,
+                            PageRequest.of(0, 3) //상위 N개 수정 필요
+                    );
+
+            List<HotQuizDto> hotQuizDtos = hotQuizzes.stream()
+                    .map(this::convertToHotQuizDto)
+                    .collect(Collectors.toList());
+
+            //카테고리 이름을 문자열로 변환(한글로)
+            hotQuizzesByCategory.put(category.name(), hotQuizDtos);
+        }
+
+        //응답 생성
+        return CommunityHomeResponse.builder()
+                .date(date)
+                .todayQuiz(convertToTodayQuizDto(todayQuiz))
+                .hotQuizzesByCategory(hotQuizzesByCategory)
+                .build();
+    }
+
+    //게시글 목록 조회
+    public List<QuizListDto> getQuizList(LocalDate date, String sortBy){
+        //오늘의 질문(SYSTEM) 조회
+        Optional<Quiz> todayQuizOpt=quizRepository.findByPublishedDateAndOrigin(date, Origin.SYSTEM);
+
+        //사용자 질문(USER) 조회
+        List<Quiz> userQuizzes;
+
+        //최신순 정렬
+        if("latest".equals(sortBy)){
+            // 최신순: USER 질문만 조회
+            userQuizzes = quizRepository.findByPublishedDateAndOriginOrderByCreatedAtDesc(date, Origin.USER);
+        }
+
+        //인기순 정렬(댓글 수 기반 정렬 추가 필요)
+        else if("popular".equals(sortBy)){
+            // 임시로 최신순 사용
+            userQuizzes = quizRepository.findByPublishedDateAndOriginOrderByCreatedAtDesc(date, Origin.USER);
+        } else {
+            userQuizzes = quizRepository.findByPublishedDateAndOriginOrderByCreatedAtDesc(date, Origin.USER);
+        }
+
+        //SYSTEM을 맨 위에, USER를 아래에 배치
+        List<QuizListDto> result = new ArrayList<>();
+
+        todayQuizOpt.ifPresent(quiz -> result.add(convertToQuizListDto(quiz)));
+
+        List<QuizListDto> userQuizDtos = userQuizzes.stream()
+                .map(this::convertToQuizListDto)
+                .collect(Collectors.toList());
+        result.addAll(userQuizDtos);
+        return result;
+    }
+
+    //Dto 변환 메서드들
+    private TodayQuizDto convertToTodayQuizDto(Quiz quiz) {
+        return TodayQuizDto.builder()
+                .quizId(quiz.getQuizId())
+                .content(quiz.getContent())
+                .category(quiz.getCategory().name())
+                .publishDate(quiz.getPublishedDate())
+                .build();
+    }
+
+    private HotQuizDto convertToHotQuizDto(Quiz quiz) {
+        return HotQuizDto.builder()
+                .quizId(quiz.getQuizId())
+                .content(quiz.getContent())
+                .category(quiz.getCategory().name())
+                .likeCount(0L) //Like 테이블 연동 후 실제 값으로 변경 필요
+                .commentCount(0L) //Comment 테이블 연동 후 실제 값으로 변경 필요
+                .createdAt(quiz.getCreatedAt())
+                .build();
+    }
+
+    private QuizListDto convertToQuizListDto(Quiz quiz) {
+        return QuizListDto.builder()
+                .quizId(quiz.getQuizId())
+                .content(quiz.getContent())
+                .category(quiz.getCategory().name())
+                .likeCount(0L) //Like 테이블 연동 후 실제 값으로 변경 필요
+                .commentCount(0L) //Comment 테이블 연동 후 실제 값으로 변경 필요
+                .publishedDate(quiz.getPublishedDate())
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
커뮤니티 첫 화면 구현
---

## 🔗 포스트맨 이미지
<img width="1273" height="898" alt="스크린샷 2025-11-03 오후 9 06 46" src="https://github.com/user-attachments/assets/ddaa83bd-23d5-4012-b912-5c2edcc1f11a" />
<img width="1273" height="898" alt="스크린샷 2025-11-03 오후 9 06 40" src="https://github.com/user-attachments/assets/760f1413-7587-4673-bf45-1a5f4a264b1a" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->
ComunityController, ComunityService, dto.community 추가했습니다.
---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- url: 
http://localhost:8080/api/community/quizzes?date=날짜&sortBy=popular (인기순)
http://localhost:8080/api/community/quizzes?date=날짜&sortBy=latest (최신순)
- GET