### PR TITLE
[FEAT] 평일 오늘의 퀴즈 카테고리 별 반환

### DIFF
--- a/src/main/java/com/example/quizley/config/CustomUserDetails.java
+++ b/src/main/java/com/example/quizley/config/CustomUserDetails.java
@@ -8,12 +8,12 @@ import java.util.Collection;
 // 유저 상세 정보
 public class CustomUserDetails implements UserDetails {
 
-    private final Integer id;       // PK
+    private final Long id;       // PK
     private final String username;  // 로그인 아이디
     private final String password;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public CustomUserDetails(Integer id, String username, String password,
+    public CustomUserDetails(Long id, String username, String password,
                              Collection<? extends GrantedAuthority> authorities) {
         this.id = id;
         this.username = username;
@@ -21,7 +21,7 @@ public class CustomUserDetails implements UserDetails {
         this.authorities = authorities;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/com/example/quizley/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/quizley/config/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 
 // 전체 예외 처리 클래스
@@ -75,6 +76,9 @@ public class GlobalExceptionHandler {
             case "FORBIDDEN" -> "권한이 없습니다";
             case "INVALID_PASSWORD" -> "비밀번호가 일치하지 않습니다.";
             case "CONSTRAINT_VIOLATION" -> "데이터 무결성 위반";
+            case "INVALID_CATEGORY"    -> "카테고리 값을 확인해주세요.";
+            case "QUIZ_NOT_FOUND"      -> "오늘의 퀴즈를 찾을 수 없습니다.";
+            case "ALREADY_COMPLETED"   -> "이미 응답한 퀴즈입니다.";
             default -> "요청을 처리할 수 없습니다.";
         };
         return ApiError.of(ex.getStatusCode().value(), code != null ? code : "ERROR", msg);
@@ -128,6 +132,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleUnsupportedMediaType(org.springframework.web.HttpMediaTypeNotSupportedException ex) {
         return ApiError.of(415, "UNSUPPORTED_MEDIA_TYPE",
                 "요청의 Content-Type이 올바르지 않습니다.");
+    }
+
+    // 카테고리 ENUM 바인딩 실패
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<?> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        if (ex.getRequiredType() != null && ex.getRequiredType().isEnum()) {
+            return ApiError.of(400, "INVALID_CATEGORY", "카테고리 값을 확인해주세요.");
+        }
+        return ApiError.of(400, "BAD_REQUEST", "요청 파라미터가 올바르지 않습니다.");
     }
 
     // 그 외 멀티파트 처리 중 예외(랩핑된 경우 포함)

--- a/src/main/java/com/example/quizley/controller/TodayController.java
+++ b/src/main/java/com/example/quizley/controller/TodayController.java
@@ -1,0 +1,54 @@
+package com.example.quizley.controller;
+
+import com.example.quizley.config.CustomUserDetails;
+import com.example.quizley.domain.Category;
+import com.example.quizley.service.QuizService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+
+// 오늘의 퀴즈
+@RestController
+@RequestMapping("/api/today")
+@RequiredArgsConstructor
+public class TodayController {
+
+    private final QuizService quizService;
+
+    // 오늘의 퀴즈 조회
+    @GetMapping(value = "")
+    public ResponseEntity<?> findTodayQuiz(
+            @AuthenticationPrincipal CustomUserDetails me,
+            @RequestParam Category category
+    ) throws Exception {
+        // 권한이 없을 때
+        if (me == null) return ResponseEntity.status(401).build();
+
+        // 카테고리가 비어있을 때
+        if (category == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_CATEGORY");
+        }
+
+        // 오늘 날짜 조회
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        DayOfWeek dow = today.getDayOfWeek();
+
+        // 주말 여부 확인
+        boolean weekend = (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY);
+
+        // 평일이라면
+        if (!weekend) {
+            return ResponseEntity.ok(quizService.getWeekdayQuiz(today, String.valueOf(category), me.getId()));
+        }
+
+        // TODO : 주말일 때 데이터 반환
+        return ResponseEntity.ok(quizService.getWeekdayQuiz(today, String.valueOf(category), me.getId()));
+    }
+}

--- a/src/main/java/com/example/quizley/domain/CommentAnonymous.java
+++ b/src/main/java/com/example/quizley/domain/CommentAnonymous.java
@@ -1,0 +1,7 @@
+package com.example.quizley.domain;
+
+
+// 응답 공개 여부
+public enum CommentAnonymous {
+    OPEN, CLOSE;
+}

--- a/src/main/java/com/example/quizley/domain/Status.java
+++ b/src/main/java/com/example/quizley/domain/Status.java
@@ -1,0 +1,7 @@
+package com.example.quizley.domain;
+
+
+// 응답 진행 중, 응답 완료 여부
+public enum Status {
+    PROGRESS, DONE
+}

--- a/src/main/java/com/example/quizley/dto/quiz/WeekdayQuizResDto.java
+++ b/src/main/java/com/example/quizley/dto/quiz/WeekdayQuizResDto.java
@@ -1,0 +1,33 @@
+package com.example.quizley.dto.quiz;
+
+import com.example.quizley.domain.Category;
+import com.example.quizley.entity.quiz.Quiz;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDate;
+
+
+// 평일 오늘의 질문 반환
+@Getter @Setter
+@Builder
+public class WeekdayQuizResDto {
+    private Long quizId;
+    private String content;
+    private Category category;
+    private LocalDate published_date;
+    private boolean completed;
+
+    // 엔티티 -> DTO 변환
+    public static WeekdayQuizResDto of(Quiz q, boolean completed) {
+        return WeekdayQuizResDto.builder()
+                .quizId(q.getQuizId())
+                .content(q.getContent())
+                .category(q.getCategory())
+                .published_date(q.getPublishedDate())
+                .completed(completed)
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/example/quizley/entity/comment/Comment.java
+++ b/src/main/java/com/example/quizley/entity/comment/Comment.java
@@ -1,0 +1,55 @@
+package com.example.quizley.entity.comment;
+
+import com.example.quizley.domain.CommentAnonymous;
+import com.example.quizley.domain.Status;
+import com.example.quizley.entity.quiz.Quiz;
+import com.example.quizley.entity.users.Users;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+// 응답 및 댓글 엔티티
+@Entity
+@Table(name = "comment")
+@Getter @Setter
+@NoArgsConstructor
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+
+    @Column(nullable = false, length = 100)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status; // PROGRESS/DONE
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "comment_anonymous", nullable = false)
+    private CommentAnonymous commentAnonymous; // OPEN/CLOSE
+
+    @Column(name = "writer_anonymous", nullable = false)
+    private boolean writerAnonymous;
+
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0;
+
+    @Column(name = "created_at", nullable = false)
+    private java.time.LocalDateTime createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private java.time.LocalDateTime modifiedAt;
+
+    private java.time.LocalDateTime deletedAt;
+}

--- a/src/main/java/com/example/quizley/repository/CommentRepository.java
+++ b/src/main/java/com/example/quizley/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.example.quizley.repository;
+
+import com.example.quizley.entity.comment.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 댓글, 응답 레포지토리
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    // 퀴즈 아이디와 유저 아이디로 응답 여부 확인
+    boolean existsByQuiz_QuizIdAndUser_UserId(Long quizId, Long userId);
+}

--- a/src/main/java/com/example/quizley/repository/QuizRepository.java
+++ b/src/main/java/com/example/quizley/repository/QuizRepository.java
@@ -19,16 +19,16 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
             Category category
     );
 
-    //커뮤니티 기능: 오늘의 질문 조회
+    // 커뮤니티 기능: 오늘의 질문 조회
     Optional<Quiz> findByPublishedDateAndOrigin(
             LocalDate publishedDate,
             Origin origin
     );
 
-    //특정 날짜의 모든 질문 조회(최신순)
+    // 특정 날짜의 모든 질문 조회(최신순)
     List<Quiz> findByPublishedDateOrderByCreatedAtDesc(LocalDate publishedDate);
 
-    //특정 날짜, 특정 카테고리의 질문 조회(최신순, 상위 N개)
+    // 특정 날짜, 특정 카테고리의 질문 조회(최신순, 상위 N개)
     List<Quiz> findByPublishedDateAndCategoryOrderByCreatedAtDesc(
             LocalDate publishedDate,
             Category category,
@@ -47,6 +47,13 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     List<Quiz> findByPublishedDateAndOriginOrderByCreatedAtDesc(
             LocalDate publishedDate,
             Origin origin
+    );
+
+    // origin이 SYSTEM이고, 오늘 날짜(published_date)와 카테고리가 일치하는 퀴즈 한 건 조회
+    Optional<Quiz> findByOriginAndPublishedDateAndCategory(
+            Origin origin,
+            LocalDate publishedDate,
+            Category category
     );
 }
 

--- a/src/main/java/com/example/quizley/service/QuizService.java
+++ b/src/main/java/com/example/quizley/service/QuizService.java
@@ -1,20 +1,30 @@
 package com.example.quizley.service;
 
+import com.anthropic.errors.NotFoundException;
 import com.example.quizley.domain.*;
+import com.example.quizley.dto.quiz.WeekdayQuizResDto;
 import com.example.quizley.entity.quiz.Quiz;
+import com.example.quizley.repository.CommentRepository;
 import com.example.quizley.repository.QuizRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Map;
+import java.util.Optional;
 
 
 @Service
 @RequiredArgsConstructor
 public class QuizService {
-    private final QuizRepository repo;
+
+    private final QuizRepository quizRepository;
+    private final CommentRepository commentRepository;
     private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
 
     // 퀴즈 생성 및 일주일 뒤 공개 설정
@@ -26,7 +36,7 @@ public class QuizService {
         Category category = Category.valueOf(categoryKo);
 
         // 중복 생성 방지
-        if (repo.existsByTypeAndPublishedDateAndCategory(QuizType.WEEKDAY, published, category)) {
+        if (quizRepository.existsByTypeAndPublishedDateAndCategory(QuizType.WEEKDAY, published, category)) {
             return null; // 혹은 기존 엔티티 ID 반환 로직/스킵 로그 등
         }
 
@@ -42,7 +52,7 @@ public class QuizService {
                 .build();
 
         // 질문 저장
-        return repo.save(quiz).getQuizId();
+        return quizRepository.save(quiz).getQuizId();
     }
 
     // 카테고리 한 번에 저장
@@ -77,5 +87,42 @@ public class QuizService {
             default -> null;
         };
     }
+
+    // 평일 오늘의 질문 추출
+    public WeekdayQuizResDto getWeekdayQuiz(LocalDate date, String category, Long userId) {
+
+        // 문자열로 받은 카테고리를 ENUM으로 변환
+        Category cat = toCategory(category);
+
+        // 오늘의 질문 조회
+        Quiz quiz = quizRepository
+                .findByOriginAndPublishedDateAndCategory(Origin.SYSTEM, date, cat)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "QUIZ_NOT_FOUND"));
+
+        // 사용자의 응답 여부
+        boolean completed = commentRepository.existsByQuiz_QuizIdAndUser_UserId(quiz.getQuizId(), userId);
+
+        // 오늘의 질문 실제 반환
+        return WeekdayQuizResDto.of(quiz, completed);
+    }
+
+    // 문자열로 받은 카테고리를 ENUM으로 변환
+    private Category toCategory(String raw) {
+
+        // 카테고리가 없을 때
+        if (raw == null || raw.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_CATEGORY");
+        }
+
+        try {
+            // 한글 enum 그대로 매칭
+            return Category.valueOf(raw.trim());
+
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_CATEGORY");
+        }
+    }
+
+    // TODO : 주말 오늘의 질문 추출
 }
 

--- a/src/main/java/com/example/quizley/service/UsersService.java
+++ b/src/main/java/com/example/quizley/service/UsersService.java
@@ -60,7 +60,7 @@ public class UsersService implements UserDetailsService {
 
         // CustomUserDetails 로 래핑해서 반환
         return new CustomUserDetails(
-                user.getUserId().intValue(),    // PK
+                user.getUserId(),    // PK
                 user.getId(),                   // 로그인용 id
                 user.getPassword(),             // 비밀번호
                 Collections.emptyList()         // 권한 (필요 시 추가 가능)


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 평일 오늘의 퀴즈 카테고리별 반환
---

## 🔗 포스트맨 이미지
<img width="609" height="732" alt="image" src="https://github.com/user-attachments/assets/d957b970-9369-4462-b9cc-ba9e31027b17" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->
- 유저 PK값이 Long이어서 CustomUserDetails의 해당 타입을 Long으로 변경

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- 주말도 같은 엔드포인트에서 호출할 거라 컨트롤러 메서드를 수정할 계획입니다.