### PR TITLE
[FEAT] 커뮤니티 홈 화면 피드백 반영 수정

### DIFF
--- a/src/main/java/com/example/quizley/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/quizley/config/GlobalExceptionHandler.java
@@ -80,6 +80,9 @@ public class GlobalExceptionHandler {
             case "QUIZ_NOT_FOUND"      -> "오늘의 퀴즈를 찾을 수 없습니다.";
             case "ALREADY_COMPLETED"   -> "이미 응답한 퀴즈입니다.";
             case "QUIZ_NOT_TODAY" -> "답변 기한이 지났습니다.";
+            case "TODAY_QUIZ_NOT_FOUND" -> "오늘의 질문을 찾을 수 없습니다.";
+            case "INVALID_DATE" -> "유효하지 않은 날짜입니다.";
+            case "INVALID_SORT_TYPE" -> "유효하지 않은 정렬 타입입니다. (latest 또는 popular만 가능)";
             default -> "요청을 처리할 수 없습니다.";
         };
         return ApiError.of(ex.getStatusCode().value(), code != null ? code : "ERROR", msg);

--- a/src/main/java/com/example/quizley/controller/CommunityController.java
+++ b/src/main/java/com/example/quizley/controller/CommunityController.java
@@ -1,5 +1,7 @@
 package com.example.quizley.controller;
 
+import com.example.quizley.config.CustomUserDetails;
+import com.example.quizley.domain.Category;
 import com.example.quizley.dto.community.CommunityHomeResponse;
 import com.example.quizley.dto.community.QuizListDto;
 import com.example.quizley.service.CommunityService;
@@ -7,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
@@ -19,14 +22,17 @@ import java.util.Map;
 public class CommunityController {
     private final CommunityService communityService;
 
-    //커뮤니티 홈 화면 조회 GET /api/community/home?date=2025-10-05
+    //커뮤니티 홈 화면 조회
     @GetMapping("/home")
     public ResponseEntity<Map<String, Object>> getCommunityHome(
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(required = false) Category category,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        CommunityHomeResponse response = communityService.getCommunityHome(date);
+        Long currentUserId = (userDetails != null) ? (long) userDetails.getId() : null;
+        CommunityHomeResponse response = communityService.getCommunityHome(date, category, currentUserId);
 
-        //응답 JSON 생성
+        //응답 JSON 생성(데이터 필드가 필요하므로 직접 Map 구성)
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("status", 200);
         body.put("data", response);
@@ -34,15 +40,18 @@ public class CommunityController {
         return ResponseEntity.ok(body);
     }
 
-    //게시글 목록 조회(최신순/인기순)
+    //게시글 목록 조회
     @GetMapping("/quizzes")
     public ResponseEntity<Map<String, Object>> getQuizList(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-            @RequestParam(defaultValue = "latest") String sortBy) {
+            @RequestParam(defaultValue = "latest") String sortBy,
+            @RequestParam(required = false) Category category,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        List<QuizListDto> quizzes = communityService.getQuizList(date, sortBy);
+        Long currentUserId = (userDetails != null) ? (long) userDetails.getId() : null;
+        List<QuizListDto> quizzes = communityService.getQuizList(date, sortBy, category, currentUserId);
 
-        //응답 JSON 생성
+        //응답 JSON 생성(데이터 필드가 필요하므로 직접 Map 구성)
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("status", 200);
         body.put("message", "게시글 목록 조회 성공");

--- a/src/main/java/com/example/quizley/dto/community/CommunityHomeResponse.java
+++ b/src/main/java/com/example/quizley/dto/community/CommunityHomeResponse.java
@@ -15,5 +15,6 @@ import java.time.LocalDate;
 public class CommunityHomeResponse {
     private LocalDate date;
     private TodayQuizDto todayQuiz;
-    private Map<String, List<HotQuizDto>> hotQuizzesByCategory;
+    private Map<String, List<HotQuizDto>> quizzesByCategory;
+    private List<QuizListDto> quizzes;
 }

--- a/src/main/java/com/example/quizley/dto/community/HotQuizDto.java
+++ b/src/main/java/com/example/quizley/dto/community/HotQuizDto.java
@@ -1,9 +1,13 @@
 package com.example.quizley.dto.community;
 
+import com.example.quizley.domain.Category;
+import com.example.quizley.util.TimeFormatUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -16,5 +20,20 @@ public class HotQuizDto {
     private String category;
     private Long likeCount;
     private Long commentCount;
-    private LocalDateTime createdAt;
+    private String nickname;
+    private String createdAt;
+    private Boolean isLiked;
+
+    //생성자
+    public HotQuizDto(Long quizId, String content, Category category, String nickname,
+                      long likeCount, long commentCount, LocalDateTime createdAt, boolean isLiked) {
+        this.quizId = quizId;
+        this.content = content;
+        this.category = category.name();
+        this.nickname = (nickname != null) ? nickname : "익명";
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.createdAt = TimeFormatUtil.formatTimeAgo(createdAt);
+        this.isLiked = isLiked;
+    }
 }

--- a/src/main/java/com/example/quizley/dto/community/QuizListDto.java
+++ b/src/main/java/com/example/quizley/dto/community/QuizListDto.java
@@ -1,10 +1,14 @@
 package com.example.quizley.dto.community;
 
+import com.example.quizley.domain.Category;
+import com.example.quizley.entity.quiz.Quiz;
+import com.example.quizley.util.TimeFormatUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Getter;
 import lombok.Builder;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -17,4 +21,22 @@ public class QuizListDto {
     private Long likeCount;
     private Long commentCount;
     private LocalDate publishedDate;
+    private String nickname;
+    private Boolean isLiked;
+    private String createdAt;
+
+    //생성자
+    public QuizListDto(Long quizId, String content, Category category, String nickname,
+                       long likeCount, long commentCount, LocalDateTime createdAt,
+                       LocalDate publishedDate, boolean isLiked) {
+        this.quizId = quizId;
+        this.content = content;
+        this.category = category.name();
+        this.nickname = (nickname != null) ? nickname : "익명";
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.createdAt = TimeFormatUtil.formatTimeAgo(createdAt);
+        this.publishedDate = publishedDate;
+        this.isLiked = isLiked;
+    }
 }

--- a/src/main/java/com/example/quizley/dto/community/TodayQuizDto.java
+++ b/src/main/java/com/example/quizley/dto/community/TodayQuizDto.java
@@ -14,4 +14,5 @@ public class TodayQuizDto {
     private String content;
     private String category;
     private LocalDate publishDate;
+    private Boolean isLiked;
 }

--- a/src/main/java/com/example/quizley/entity/comment/Comment.java
+++ b/src/main/java/com/example/quizley/entity/comment/Comment.java
@@ -7,6 +7,8 @@ import com.example.quizley.entity.users.Users;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 
 // 응답 및 댓글 엔티티
 @Entity
@@ -52,4 +54,19 @@ public class Comment {
     private java.time.LocalDateTime modifiedAt;
 
     private java.time.LocalDateTime deletedAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String feedback;
+
+    @PrePersist
+    void prePersist() {
+        var now = LocalDateTime.now();
+        if (createdAt == null) createdAt = now;
+        if (modifiedAt == null) modifiedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        modifiedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/quizley/entity/quiz/Quiz.java
+++ b/src/main/java/com/example/quizley/entity/quiz/Quiz.java
@@ -7,7 +7,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import java.time.*;
 
-
 // 퀴즈 엔티티
 @Entity
 @Table(name="quiz")

--- a/src/main/java/com/example/quizley/entity/quiz/QuizLike.java
+++ b/src/main/java/com/example/quizley/entity/quiz/QuizLike.java
@@ -1,0 +1,37 @@
+package com.example.quizley.entity.quiz;
+
+import com.example.quizley.entity.quiz.QuizLikeId;
+import com.example.quizley.entity.users.Users;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_like")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@IdClass(QuizLikeId.class)
+public class QuizLike {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/example/quizley/entity/quiz/QuizLikeId.java
+++ b/src/main/java/com/example/quizley/entity/quiz/QuizLikeId.java
@@ -1,0 +1,13 @@
+package com.example.quizley.entity.quiz;
+
+import lombok.*;
+import java.io.Serializable;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class QuizLikeId implements Serializable {
+    private Long quiz;  //Quiz 엔티티의 PK타입
+    private Long user;  //Users 엔티티의 PK타입
+}

--- a/src/main/java/com/example/quizley/repository/QuizRepository.java
+++ b/src/main/java/com/example/quizley/repository/QuizRepository.java
@@ -3,9 +3,15 @@ package com.example.quizley.repository;
 import com.example.quizley.domain.Category;
 import com.example.quizley.domain.QuizType;
 import com.example.quizley.domain.Origin;
+import com.example.quizley.entity.comment.Comment;
+import com.example.quizley.dto.community.HotQuizDto;
+import com.example.quizley.dto.community.QuizListDto;
 import com.example.quizley.entity.quiz.Quiz;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -60,5 +66,80 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     boolean existsByQuizIdAndPublishedDate(Long quizId, LocalDate publishedDate);
 
     Optional<Quiz> findByQuizId(Long quizId);
-}
 
+
+
+    // 오늘의 퀴즈 좋아요 여부 확인용
+    @Query("SELECT " +
+            "(CASE WHEN :userId IS NULL THEN false " +
+            "      WHEN EXISTS (SELECT 1 FROM QuizLike l WHERE l.quiz.quizId = :quizId AND l.user.userId = :userId) THEN true " +
+            "      ELSE false END) " +
+            "FROM Quiz q " +
+            "WHERE q.quizId = :quizId")
+    Boolean isQuizLikedByUser(@Param("quizId") Long quizId, @Param("userId") Long userId);
+
+    //HOT 게시글 조회(카테고리별)
+    @Query("SELECT new com.example.quizley.dto.community.HotQuizDto(" +
+            "q.quizId, q.content, q.category, u.nickname, " +
+            "(SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId), " +
+            "(SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId), " +
+            "q.createdAt, " +
+            "(CASE WHEN :userId IS NULL THEN false " +
+            "      WHEN EXISTS (SELECT 1 FROM QuizLike l2 WHERE l2.quiz.quizId = q.quizId AND l2.user.userId = :userId) THEN true " +
+            "      ELSE false END)) " +
+            "FROM Quiz q " +
+            "LEFT JOIN Users u ON q.userId = u.userId " +
+            "WHERE q.publishedDate = :date " +
+            "AND q.origin = :origin " +
+            "AND q.category = :category " +
+            "ORDER BY q.createdAt DESC")
+    List<HotQuizDto> findHotQuizzesByCategory(
+            @Param("date") LocalDate date,
+            @Param("origin") Origin origin,
+            @Param("category") Category category,
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
+    //게시글 목록 조회(카테고리 필터링)
+    @Query("SELECT new com.example.quizley.dto.community.QuizListDto(" +
+            "q.quizId, q.content, q.category, u.nickname, " +
+            "(SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId), " +
+            "(SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId), " +
+            "q.createdAt, q.publishedDate, " +
+            "(CASE WHEN :userId IS NULL THEN false " +
+            "      WHEN EXISTS (SELECT 1 FROM QuizLike l2 WHERE l2.quiz.quizId = q.quizId AND l2.user.userId = :userId) THEN true " +
+            "      ELSE false END)) " +
+            "FROM Quiz q " +
+            "LEFT JOIN Users u ON q.userId = u.userId " +
+            "WHERE q.publishedDate = :date " +
+            "AND q.origin = :origin " +
+            "AND q.category = :category " +
+            "ORDER BY q.createdAt DESC")
+    List<QuizListDto> findQuizListByCategory(
+            @Param("date") LocalDate date,
+            @Param("origin") Origin origin,
+            @Param("category") Category category,
+            @Param("userId") Long userId
+    );
+
+    //게시글 목록 조회(전체)
+    @Query("SELECT new com.example.quizley.dto.community.QuizListDto(" +
+            "q.quizId, q.content, q.category, u.nickname, " +
+            "(SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId), " +
+            "(SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId), " +
+            "q.createdAt, q.publishedDate, " +
+            "(CASE WHEN :userId IS NULL THEN false " +
+            "      WHEN EXISTS (SELECT 1 FROM QuizLike l2 WHERE l2.quiz.quizId = q.quizId AND l2.user.userId = :userId) THEN true " +
+            "      ELSE false END)) " +
+            "FROM Quiz q " +
+            "LEFT JOIN Users u ON q.userId = u.userId " +
+            "WHERE q.publishedDate = :date " +
+            "AND q.origin = :origin " +
+            "ORDER BY q.createdAt DESC")
+    List<QuizListDto> findAllQuizList(
+            @Param("date") LocalDate date,
+            @Param("origin") Origin origin,
+            @Param("userId") Long userId
+    );
+}

--- a/src/main/java/com/example/quizley/service/CommunityService.java
+++ b/src/main/java/com/example/quizley/service/CommunityService.java
@@ -8,120 +8,142 @@ import com.example.quizley.dto.community.QuizListDto;
 import com.example.quizley.dto.community.TodayQuizDto;
 import com.example.quizley.entity.quiz.Quiz;
 import com.example.quizley.repository.QuizRepository;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
+import org.codehaus.groovy.util.ListHashMap;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import com.example.quizley.entity.comment.Comment;
+
+import java.sql.Time;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.ArrayList;
-import java.util.Optional;
 
+@Builder
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommunityService {
+
     private final QuizRepository quizRepository;
 
     //커뮤니티 홈 화면 조회
-    public CommunityHomeResponse getCommunityHome(LocalDate date) {
+    public CommunityHomeResponse getCommunityHome(LocalDate date, Category category, Long currentUserId) {
+        validateDate(date);
         //오늘의 질문 조회
-        Quiz todayQuiz = quizRepository.findByPublishedDateAndOrigin(date, Origin.SYSTEM)
-                .orElseThrow(()-> new RuntimeException("오늘의 질문이 없습니다."));
+        Quiz todayQuiz = getTodayQuiz(date);
+        Boolean isTodayQuizLiked = checkQuizLiked(todayQuiz.getQuizId(), currentUserId);
 
-        //카테고리별로 HOT 인기글 3개씩 조회
-        Map<String, List<HotQuizDto>> hotQuizzesByCategory = new LinkedHashMap<>();
+        //카테고리별 핫 게시글
+        Map<String, List<HotQuizDto>> hotQuizzesByCategory = getHotQuizzesByCategory(date, category, currentUserId);
 
-        //모든 카테고리 순회
-        for (Category category : Category.values()) {
-            List<Quiz> hotQuizzes = quizRepository
-                    .findByPublishedDateAndOriginAndCategoryOrderByCreatedAtDesc(
-                            date,
-                            Origin.USER,
-                            category,
-                            PageRequest.of(0, 3) //상위 N개 수정 필요
-                    );
-
-            List<HotQuizDto> hotQuizDtos = hotQuizzes.stream()
-                    .map(this::convertToHotQuizDto)
-                    .collect(Collectors.toList());
-
-            //카테고리 이름을 문자열로 변환(한글로)
-            hotQuizzesByCategory.put(category.name(), hotQuizDtos);
-        }
+        //이란 게시글 목록 조회(최신순)
+        List<QuizListDto> quizzes = getQuizList(date, "latest", category, currentUserId);
 
         //응답 생성
         return CommunityHomeResponse.builder()
                 .date(date)
-                .todayQuiz(convertToTodayQuizDto(todayQuiz))
-                .hotQuizzesByCategory(hotQuizzesByCategory)
+                .todayQuiz(convertToTodayQuizDto(todayQuiz, isTodayQuizLiked))
+                .quizzesByCategory(hotQuizzesByCategory)
+                .quizzes(quizzes)
                 .build();
-    }
+        }
 
     //게시글 목록 조회
-    public List<QuizListDto> getQuizList(LocalDate date, String sortBy){
-        //오늘의 질문(SYSTEM) 조회
-        Optional<Quiz> todayQuizOpt=quizRepository.findByPublishedDateAndOrigin(date, Origin.SYSTEM);
+    public List<QuizListDto> getQuizList(LocalDate date, String sortBy, Category category, Long currentUserId) {
+        validateDate(date);
+        validateSortType(sortBy);
 
-        //사용자 질문(USER) 조회
-        List<Quiz> userQuizzes;
+        //Repository에서 DTO 조회
+        List<QuizListDto> quizzes = (category != null)
+                ? quizRepository.findQuizListByCategory(date, Origin.USER, category, currentUserId)
+                : quizRepository.findAllQuizList(date, Origin.USER, currentUserId);
 
-        //최신순 정렬
-        if("latest".equals(sortBy)){
-            // 최신순: USER 질문만 조회
-            userQuizzes = quizRepository.findByPublishedDateAndOriginOrderByCreatedAtDesc(date, Origin.USER);
+        //정렬
+        if ("popular".equals(sortBy)) {
+            return sortByPopularity(quizzes);
+        }
+        return quizzes;
+    }
+
+    //오늘의 질문 조회
+    private Quiz getTodayQuiz(LocalDate date) {
+        return quizRepository.findByPublishedDateAndOrigin(date, Origin.SYSTEM)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "TODAY_QUIZ_NOT_FOUND"));
+    }
+
+    //퀴즈 좋아요 여부 확인
+    private Boolean checkQuizLiked(Long quizId, Long currentUserId) {
+        if (currentUserId == null) {
+            return false;
         }
 
-        //인기순 정렬(댓글 수 기반 정렬 추가 필요)
-        else if("popular".equals(sortBy)){
-            // 임시로 최신순 사용
-            userQuizzes = quizRepository.findByPublishedDateAndOriginOrderByCreatedAtDesc(date, Origin.USER);
-        } else {
-            userQuizzes = quizRepository.findByPublishedDateAndOriginOrderByCreatedAtDesc(date, Origin.USER);
+        Boolean isLiked = quizRepository.isQuizLikedByUser(quizId, currentUserId);
+        return isLiked != null ? isLiked : false;
+    }
+
+    //카테고리별 HOT 게시글 조회
+    private Map<String, List<HotQuizDto>> getHotQuizzesByCategory(
+            LocalDate date, Category category, Long currentUserId) {
+
+        Map<String, List<HotQuizDto>> result = new LinkedHashMap<>();
+
+        List<Category> categories = (category != null)
+                ? List.of(category)
+                : Arrays.asList(Category.values());
+
+        //각 카테고리별 핫 게시글 조회 (상위 3개)
+        for (Category cat : categories) {
+            List<HotQuizDto> hotQuizzes = quizRepository.findHotQuizzesByCategory(
+                    date, Origin.USER, cat, currentUserId, PageRequest.of(0, 3)
+            );
+            result.put(cat.name(), hotQuizzes);
         }
-
-        //SYSTEM을 맨 위에, USER를 아래에 배치
-        List<QuizListDto> result = new ArrayList<>();
-
-        todayQuizOpt.ifPresent(quiz -> result.add(convertToQuizListDto(quiz)));
-
-        List<QuizListDto> userQuizDtos = userQuizzes.stream()
-                .map(this::convertToQuizListDto)
-                .collect(Collectors.toList());
-        result.addAll(userQuizDtos);
         return result;
     }
 
-    //Dto 변환 메서드들
-    private TodayQuizDto convertToTodayQuizDto(Quiz quiz) {
+    //인기순 정렬
+    private List<QuizListDto> sortByPopularity(List<QuizListDto> quizzes) {
+        return quizzes.stream()
+                .sorted((q1, q2) -> {
+                    Long popularity1 = q1.getLikeCount() + q1.getCommentCount();
+                    Long popularity2 = q2.getLikeCount() + q2.getCommentCount();
+                    return popularity2.compareTo(popularity1);
+                })
+                .collect(Collectors.toList());
+    }
+
+    //퀴즈 엔티티를 TodayQuizDto로 변환
+    private TodayQuizDto convertToTodayQuizDto(Quiz quiz, Boolean isLiked) {
         return TodayQuizDto.builder()
                 .quizId(quiz.getQuizId())
                 .content(quiz.getContent())
                 .category(quiz.getCategory().name())
                 .publishDate(quiz.getPublishedDate())
+                .isLiked(isLiked)
                 .build();
     }
 
-    private HotQuizDto convertToHotQuizDto(Quiz quiz) {
-        return HotQuizDto.builder()
-                .quizId(quiz.getQuizId())
-                .content(quiz.getContent())
-                .category(quiz.getCategory().name())
-                .likeCount(0L) //Like 테이블 연동 후 실제 값으로 변경 필요
-                .commentCount(0L) //Comment 테이블 연동 후 실제 값으로 변경 필요
-                .createdAt(quiz.getCreatedAt())
-                .build();
+    //날짜 유효성 검증
+    private void validateDate(LocalDate date) {
+        if (date == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_DATE");
+        }
     }
 
-    private QuizListDto convertToQuizListDto(Quiz quiz) {
-        return QuizListDto.builder()
-                .quizId(quiz.getQuizId())
-                .content(quiz.getContent())
-                .category(quiz.getCategory().name())
-                .likeCount(0L) //Like 테이블 연동 후 실제 값으로 변경 필요
-                .commentCount(0L) //Comment 테이블 연동 후 실제 값으로 변경 필요
-                .publishedDate(quiz.getPublishedDate())
-                .build();
+    //정렬 타입 유효성 검증
+    private void validateSortType(String sortBy) {
+        if (sortBy == null || sortBy.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_SORT_TYPE");
+        }
+
+        if (!"latest".equals(sortBy) && !"popular".equals(sortBy)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_SORT_TYPE");
+        }
     }
 }

--- a/src/main/java/com/example/quizley/util/TimeFormatUtil.java
+++ b/src/main/java/com/example/quizley/util/TimeFormatUtil.java
@@ -1,0 +1,27 @@
+package com.example.quizley.util;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeFormatUtil {
+    public static String formatTimeAgo(LocalDateTime createdAt) {
+        LocalDateTime now = LocalDateTime.now();
+        Duration duration = Duration.between(createdAt, now);
+
+        long minutes = duration.toMinutes();
+        Long hours = duration.toHours();
+
+        if (minutes < 1) {
+            return "방금 전";
+        } else if(minutes <60){
+            return minutes + "분 전";
+        } else if(hours < 24){
+            return hours + "시간 전";
+        } else {
+            //24시간 이상이면 날짜만 표시
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+            return createdAt.format(formatter);
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 사용자 닉네임 출력
- created_at 데이터 정제
- JSON key 이름 수정
- 엔드포인트 통합
- 좋아요 여부
---

## 🔗 포스트맨 이미지
<img width="1052" height="767" alt="postman_#49" src="https://github.com/user-attachments/assets/f4a31a39-dbd2-4d96-a70f-72fd48c3d077" />
<img width="1052" height="767" alt="postman_#49_2" src="https://github.com/user-attachments/assets/1c4beae7-443a-4db5-a235-c4b7364754cf" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->
entity/quiz/comment 가 불필요하여 삭제하고 entity/comment/Comment를 사용하였습니다.
---

## 📝 비고
<!-- 추가로 전달할 사항 -->
GET 요청: /api/community/home