### PR TITLE
[FEAT]: 상세 페이지 열람(조회, 좋아요, 댓글) 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 	testImplementation 'org.mockito:mockito-core:5.10.0'
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
 
-	// implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 
 def querydslDir = "$buildDir/generated/sources/annotationProcessor/java"

--- a/src/main/java/com/example/quizley/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/quizley/config/GlobalExceptionHandler.java
@@ -83,6 +83,9 @@ public class GlobalExceptionHandler {
             case "TODAY_QUIZ_NOT_FOUND" -> "오늘의 질문을 찾을 수 없습니다.";
             case "INVALID_DATE" -> "유효하지 않은 날짜입니다.";
             case "INVALID_SORT_TYPE" -> "유효하지 않은 정렬 타입입니다. (latest 또는 popular만 가능)";
+            case "COMMENT_NOT_FOUND" -> "댓글을 찾을 수 없습니다.";
+            case "CANNOT_LIKE_SYSTEM_QUIZ" -> "시스템 퀴즈에는 좋아요를 누를 수 없습니다.";
+            case "CANNOT_COMMENT_ON_SYSTEM_QUIZ" -> "시스템 퀴즈에는 댓글을 작성할 수 없습니다.";
             default -> "요청을 처리할 수 없습니다.";
         };
         return ApiError.of(ex.getStatusCode().value(), code != null ? code : "ERROR", msg);

--- a/src/main/java/com/example/quizley/dto/community/CommentCreateDto.java
+++ b/src/main/java/com/example/quizley/dto/community/CommentCreateDto.java
@@ -1,0 +1,14 @@
+package com.example.quizley.dto.community;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentCreateDto {
+    private String content;
+    private Boolean isAnonymous; // 익명 여부
+}

--- a/src/main/java/com/example/quizley/dto/community/CommentDto.java
+++ b/src/main/java/com/example/quizley/dto/community/CommentDto.java
@@ -1,0 +1,32 @@
+package com.example.quizley.dto.community;
+import com.example.quizley.util.TimeFormatUtil;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentDto {
+    private Long commentId;
+    private String content;
+    private String nickname; // 작성자 닉네임 또는 익명
+    private Integer likeCount;
+    private Boolean isLiked;
+    private String createdAt;
+
+    // 생성자
+    public CommentDto(Long commentId, String content, String nickname,
+                      Integer likeCount, Boolean isLiked, LocalDateTime createdAt) {
+        this.commentId = commentId;
+        this.content = content;
+        this.nickname = nickname;
+        this.likeCount = likeCount;
+        this.isLiked = isLiked;
+        this.createdAt = TimeFormatUtil.formatTimeAgo(createdAt);
+    }
+}

--- a/src/main/java/com/example/quizley/dto/community/QuizDetailDto.java
+++ b/src/main/java/com/example/quizley/dto/community/QuizDetailDto.java
@@ -1,0 +1,27 @@
+package com.example.quizley.dto.community;
+
+import com.example.quizley.domain.Category;
+import com.example.quizley.domain.Origin;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizDetailDto {
+    private Long quizId;
+    private String content;
+    private String nickname; // 닉네임 또는 익명
+    private Long likeCount;
+    private Long commentCount;
+    private String createdAt;
+    private Boolean isLiked;
+    private Origin origin;
+    private Boolean canLike; // 좋아요 가능 여부 (SYSTEM이면 false)
+    private Boolean canComment; // 댓글 작성 가능 여부 (SYSTEM이면 false)
+}

--- a/src/main/java/com/example/quizley/dto/community/QuizDetailResponse.java
+++ b/src/main/java/com/example/quizley/dto/community/QuizDetailResponse.java
@@ -1,0 +1,16 @@
+package com.example.quizley.dto.community;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.Builder;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuizDetailResponse {
+    private QuizDetailDto quiz;
+    private List<CommentDto> comments;
+}

--- a/src/main/java/com/example/quizley/entity/comment/CommentLike.java
+++ b/src/main/java/com/example/quizley/entity/comment/CommentLike.java
@@ -1,0 +1,36 @@
+package com.example.quizley.entity.comment;
+import com.example.quizley.entity.users.Users;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comment_like")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@IdClass(CommentLikeId.class)
+public class CommentLike {
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/example/quizley/entity/comment/CommentLikeId.java
+++ b/src/main/java/com/example/quizley/entity/comment/CommentLikeId.java
@@ -1,0 +1,13 @@
+package com.example.quizley.entity.comment;
+import lombok.*;
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class CommentLikeId implements Serializable {
+    private Long comment; // Comment 엔티티의 PK 타입
+    private Long user; // Users 엔티티의 PK 타입
+}

--- a/src/main/java/com/example/quizley/repository/CommentLikeRepository.java
+++ b/src/main/java/com/example/quizley/repository/CommentLikeRepository.java
@@ -1,0 +1,13 @@
+package com.example.quizley.repository;
+import com.example.quizley.entity.comment.CommentLike;
+import com.example.quizley.entity.comment.CommentLikeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+public interface CommentLikeRepository extends JpaRepository<CommentLike, CommentLikeId>{
+    // 특정 사용자가 특정 댓글에 좋아요를 눌렀는지 확인
+    boolean existsByComment_CommentIdAndUser_UserId(Long commentId, Long userId);
+
+    // 특정 사용자의 특정 댓글 좋아요 찾기
+    Optional<CommentLike> findByComment_CommentIdAndUser_UserId(Long commentId, Long userId);
+}

--- a/src/main/java/com/example/quizley/repository/CommentRepository.java
+++ b/src/main/java/com/example/quizley/repository/CommentRepository.java
@@ -1,10 +1,64 @@
 package com.example.quizley.repository;
 
+import com.example.quizley.dto.community.CommentDto;
 import com.example.quizley.entity.comment.Comment;
+import com.example.quizley.entity.quiz.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 // 댓글, 응답 레포지토리
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 퀴즈 아이디와 유저 아이디로 응답 여부 확인
     boolean existsByQuiz_QuizIdAndUser_UserId(Long quizId, Long userId);
+
+    // 특정 퀴즈의 댓글 목록 조회 (생성 시간 기준 정렬)
+    @Query("SELECT new com.example.quizley.dto.community.CommentDto(" +
+            "c.commentId, c.content, " +
+            "CASE WHEN c.writerAnonymous = true THEN '익명' ELSE u.nickname END, " +
+            "c.likeCount, " +
+            "(CASE WHEN :userId IS NULL THEN false " +
+            "      WHEN EXISTS (SELECT 1 FROM CommentLike cl WHERE cl.comment.commentId = c.commentId AND cl.user.userId = :userId) THEN true " +
+            "      ELSE false END), " +
+            "c.createdAt) " +
+            "FROM Comment c " +
+            "LEFT JOIN Users u ON c.user.userId = u.userId " +
+            "WHERE c.quiz.quizId = :quizId " +
+            "AND c.deletedAt IS NULL " +
+            "ORDER BY c.createdAt ASC")
+    List<CommentDto> findCommentsByQuizId(@Param("quizId") Long quizId, @Param("userId") Long userId);
+
+    // 최신순
+    @Query("SELECT new com.example.quizley.dto.community.CommentDto(" +
+            "c.commentId, c.content, " +
+            "CASE WHEN c.writerAnonymous = true THEN '익명' ELSE u.nickname END, " +
+            "c.likeCount, " +
+            "(CASE WHEN :userId IS NULL THEN false " +
+            "      WHEN EXISTS (SELECT 1 FROM CommentLike cl WHERE cl.comment.commentId = c.commentId AND cl.user.userId = :userId) THEN true " +
+            "      ELSE false END), " +
+            "c.createdAt) " +
+            "FROM Comment c " +
+            "LEFT JOIN c.user u " +
+            "WHERE c.quiz.quizId = :quizId " +
+            "AND c.deletedAt IS NULL " +
+            "ORDER BY c.createdAt DESC")
+    List<CommentDto> findCommentsByQuizIdOrderByLatest(@Param("quizId") Long quizId, @Param("userId") Long userId);
+
+    // 인기순 쿼리
+    @Query("SELECT new com.example.quizley.dto.community.CommentDto(" +
+            "c.commentId, c.content, " +
+            "CASE WHEN c.writerAnonymous = true THEN '익명' ELSE u.nickname END, " +
+            "c.likeCount, " +
+            "(CASE WHEN :userId IS NULL THEN false " +
+            "      WHEN EXISTS (SELECT 1 FROM CommentLike cl WHERE cl.comment.commentId = c.commentId AND cl.user.userId = :userId) THEN true " +
+            "      ELSE false END), " +
+            "c.createdAt) " +
+            "FROM Comment c " +
+            "LEFT JOIN c.user u " +
+            "WHERE c.quiz.quizId = :quizId " +
+            "AND c.deletedAt IS NULL " +
+            "ORDER BY c.likeCount DESC, c.createdAt DESC")
+    List<CommentDto> findCommentsByQuizIdOrderByPopular(@Param("quizId") Long quizId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/example/quizley/repository/QuizLikeRepository.java
+++ b/src/main/java/com/example/quizley/repository/QuizLikeRepository.java
@@ -1,0 +1,14 @@
+package com.example.quizley.repository;
+import com.example.quizley.entity.quiz.QuizLike;
+import com.example.quizley.entity.quiz.QuizLikeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface QuizLikeRepository extends JpaRepository<QuizLike, QuizLikeId> {
+    // 특정 사용자가 특정 퀴즈에 좋아요 눌렀는지 확인
+    boolean existsByQuiz_QuizIdAndUser_UserId(Long quizId, Long userId);
+
+    // 특정 사용자의 특정 퀴즈 좋아요 찾기
+    Optional<QuizLike> findByQuiz_QuizIdAndUser_UserId(Long quizId, Long userId);
+}

--- a/src/main/java/com/example/quizley/repository/QuizRepository.java
+++ b/src/main/java/com/example/quizley/repository/QuizRepository.java
@@ -142,4 +142,12 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
             @Param("origin") Origin origin,
             @Param("userId") Long userId
     );
+
+    // 퀴즈 좋아요 개수 조회
+    @Query("SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = :quizId")
+    Long countLikesByQuizId(@Param("quizId") Long quizId);
+
+    // 댓글 개수 조회
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = :quizId")
+    Long countCommentsByQuizId(@Param("quizId") Long quizId);
 }

--- a/src/main/java/com/example/quizley/service/CommunityDetailService.java
+++ b/src/main/java/com/example/quizley/service/CommunityDetailService.java
@@ -1,0 +1,187 @@
+package com.example.quizley.service;
+import com.example.quizley.domain.Origin;
+import com.example.quizley.dto.community.*;
+import com.example.quizley.entity.comment.Comment;
+import com.example.quizley.entity.comment.CommentLike;
+import com.example.quizley.entity.quiz.Quiz;
+import com.example.quizley.entity.quiz.QuizLike;
+import com.example.quizley.entity.users.Users;
+import com.example.quizley.repository.*;
+import com.example.quizley.util.TimeFormatUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommunityDetailService {
+    private final QuizRepository quizRepository;
+    private final QuizLikeRepository quizLikeRepository;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final UsersRepository usersRepository;
+
+    // 게시글 상세 조회
+    public QuizDetailResponse getQuizDetail(Long quizId, Long currentUserId, String sort) {
+        // 퀴즈 조회
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "QUIZ_NOT_FOUND"));
+
+        // 좋아요 수 조회
+        Long likeCount = quizRepository.countLikesByQuizId(quizId);
+
+        //댓글 수 조회
+        Long commentCount = quizRepository.countCommentsByQuizId(quizId);
+
+        // 사용자의 좋아요 여부 확인
+        Boolean isLiked = false;
+        if (currentUserId != null) {
+            isLiked = quizLikeRepository.existsByQuiz_QuizIdAndUser_UserId(quizId, currentUserId);
+        }
+
+        // 작성자 닉네임 조회 (익명 처리)
+        String nickname = "익명"; //나중에 익명 처리 구현
+        if (quiz.getUserId() != null && !quiz.getIsAnonymous()) {
+            Users user = usersRepository.findById(quiz.getUserId())
+                    .orElseThrow(null);
+            if (user != null) {
+                nickname = user.getNickname();
+            }
+        }
+
+        //QuizDetailDto 생성
+        QuizDetailDto quizDetail = QuizDetailDto.builder()
+                .quizId(quiz.getQuizId())
+                .content(quiz.getContent())
+                .nickname(nickname)
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .createdAt(TimeFormatUtil.formatTimeAgo(quiz.getCreatedAt()))
+                .isLiked(isLiked)
+                .origin(quiz.getOrigin())
+                .canLike(quiz.getOrigin() == Origin.USER)  // USER 질문만 좋아요 가능
+                .canComment(quiz.getOrigin() == Origin.USER)  // USER 질문만 댓글 작성 가능
+                .build();
+
+        // 댓글 목록 조회
+        List<CommentDto> comments = getCommentsWithTimeFormat(quizId, currentUserId, sort);
+
+        return QuizDetailResponse.builder()
+                .quiz(quizDetail)
+                .comments(comments)
+                .build();
+    }
+
+    // 댓글 목록 조회
+    private List<CommentDto> getCommentsWithTimeFormat(Long quizId, Long currentUserId, String sort) {
+        if ("popular".equalsIgnoreCase(sort)) {
+            // 인기순 (좋아요 많은 순) 쿼리 호출
+            return commentRepository.findCommentsByQuizIdOrderByPopular(quizId, currentUserId);
+        }
+
+        // 기본값 latest(최신순) 쿼리 호출
+        return commentRepository.findCommentsByQuizIdOrderByLatest(quizId, currentUserId);
+    }
+
+    // 퀴즈 좋아요
+    @Transactional
+    public void selectQuizLike(Long quizId, Long userId) {
+        // 퀴즈 조회
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "QUIZ_NOT_FOUND"));
+
+        // SYSTEM 퀴즈는 좋아요 불가
+        if (quiz.getOrigin() == Origin.SYSTEM) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CANNOT_LIKE_SYSTEM_QUIZ");
+        }
+
+        // 사용자 조회
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"));
+
+        // 좋아요 존재 여부 확인
+        var existingLike = quizLikeRepository.findByQuiz_QuizIdAndUser_UserId(quizId, userId);
+        if (existingLike.isPresent()) {
+            // 좋아요 취소
+            quizLikeRepository.delete(existingLike.get());
+        } else {
+            // 좋아요 추가
+            QuizLike quizLike = QuizLike.builder()
+                    .quiz(quiz)
+                    .user(user)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            quizLikeRepository.save(quizLike);
+        }
+    }
+
+    // 댓글 작성
+    @Transactional
+    public Long createComment(Long quizId, CommentCreateDto commentCreateDto, Long userId) {
+        // 퀴즈 조회
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "QUIZ_NOT_FOUND"));
+
+        // SYSTEM 퀴즈는 댓글 작성 불가
+        if (quiz.getOrigin() == Origin.SYSTEM) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "CANNOT_COMMENT_ON_SYSTEM_QUIZ");
+        }
+
+        // 사용자 조회
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"));
+
+        // 댓글 생성
+        Comment comment = new Comment();
+        comment.setQuiz(quiz);
+        comment.setUser(user);
+        comment.setContent(commentCreateDto.getContent());
+        comment.setWriterAnonymous(commentCreateDto.getIsAnonymous() != null && commentCreateDto.getIsAnonymous());
+        comment.setStatus(com.example.quizley.domain.Status.DONE);
+        comment.setCommentAnonymous(com.example.quizley.domain.CommentAnonymous.OPEN);
+        comment.setLikeCount(0);
+        comment.setCreatedAt(LocalDateTime.now());
+        comment.setModifiedAt(LocalDateTime.now());
+
+        Comment savedComment = commentRepository.save(comment);
+        return savedComment.getCommentId();
+    }
+
+    // 댓글 좋아요 토글
+    @Transactional
+    public void selectCommentLike(Long commentId, Long userId) {
+        // 댓글 조회
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND"));
+
+        // 사용자 조회
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"));
+
+        // 좋아요 존재 여부 확인
+        var existingLike = commentLikeRepository.findByComment_CommentIdAndUser_UserId(commentId, userId);
+        if (existingLike.isPresent()) {
+            // 좋아요 취소
+            commentLikeRepository.delete(existingLike.get());
+            comment.setLikeCount(comment.getLikeCount() - 1);
+        } else {
+            // 좋아요 증가
+            CommentLike commentLike = CommentLike.builder()
+                    .comment(comment)
+                    .user(user)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            commentLikeRepository.save(commentLike);
+            comment.setLikeCount(comment.getLikeCount() + 1);
+        }
+        commentRepository.save(comment);
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->

- 상세 페이지 조회
- 좋아요, 댓글 조회

---

## 🔗 포스트맨 이미지

<img width="747" height="595" alt="1전체조회" src="https://github.com/user-attachments/assets/5aeb3239-fff2-43e4-a039-6f7441be4896" />
<img width="747" height="164" alt="2좋아요" src="https://github.com/user-attachments/assets/a7cdc584-fe5f-43f6-ba74-8aa7e6bc0de6" />
<img width="747" height="248" alt="3댓글" src="https://github.com/user-attachments/assets/c491b927-c5cf-4504-8668-2b7150400398" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- /api/community/quiz/{quizId}
- /api/community/quiz/{quizId}/like
- /api/community/quiz/{quizId}/comment