### PR TITLE
[FEAT] 커뮤니티 게시글 좋아요

### DIFF
--- a/src/main/java/com/example/quizley/dto/community/QuizDetailDto.java
+++ b/src/main/java/com/example/quizley/dto/community/QuizDetailDto.java
@@ -20,8 +20,8 @@ public class QuizDetailDto {
     private Long likeCount;
     private Long commentCount;
     private String createdAt;
-    private Boolean isLiked;
+    private Boolean isLiked; // 사용자가 해당 게시글에 좋아요를 눌렀는지 여부
     private Origin origin;
-    private Boolean canLike; // 좋아요 가능 여부 (SYSTEM이면 false)
-    private Boolean canComment; // 댓글 작성 가능 여부 (SYSTEM이면 false)
+    private Boolean canLike; // 좋아요 기능 활성화 여부, SYSTEM 퀴즈는 좋아요 불가 (SYSTEM이면 false)
+    private Boolean canComment; // 댓글 작성 기능 활성화 여부, SYSTEM 퀴즈는 작성 불가 (SYSTEM이면 false)
 }


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->

- 커뮤니티 게시글 좋아요 기능 구현
- 같은 아이디로 두 번 누를 경우 좋아요 취소
- SYSTEM 게시글 불가능, USER 게시글만 좋아요 가능

---

## 🔗 포스트맨 이미지

좋아요 처리 결과
<img width="733" height="431" alt="2-좋아요처리완료" src="https://github.com/user-attachments/assets/ad5af0a1-bfe1-42f6-be57-8a8a2dc32307" />

상세페이지 열람 시, 누적된 모습(likeCount)
<img width="733" height="434" alt="2-상세페이지(좋아요 누적)" src="https://github.com/user-attachments/assets/fefb137b-26dd-427a-80ec-19b7e37735ce" />

SYSTEM 퀴즈에 좋아요 보낼 경우 실패
<img width="733" height="198" alt="3-시스템퀴즈 실패" src="https://github.com/user-attachments/assets/915ef74d-0360-4f68-8f1d-25e20df9884e" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- canLike: 시스템 질문과 유저 질문의 좋아요 여부가 달라 이를 구분하기 위함 (명확히 분리하는 게 좋을 것 같아 나눴습니다.)
- isLiked: 실제 좋아요 기능 동작 (USER 질문에서만 가능)