### PR TITLE
[FEAT] 리포트 분석 및 분석 결과 반환

### DIFF
--- a/src/main/java/com/example/quizley/controller/CalendarController.java
+++ b/src/main/java/com/example/quizley/controller/CalendarController.java
@@ -1,11 +1,13 @@
 package com.example.quizley.controller;
 
+import com.example.quizley.config.CustomUserDetails;
 import com.example.quizley.dto.calendar.CalendarResponseDto;
 import com.example.quizley.service.CalendarService;
 import com.example.quizley.config.jwt.JwtProvider;
 import com.example.quizley.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,19 +22,13 @@ public class CalendarController {
     // 로그인된 사용자의 캘린더 응답 기록 조회
     @GetMapping
     public ResponseEntity<CalendarResponseDto> getCalendar(
-            @RequestHeader("Authorization") String token) {
-
-        // JWT에서 로그인 ID 추출
-        String jwt = token.replace("Bearer ", "");
-        String loginId = jwtProvider.getSubject(jwt);
-
-        // 로그인 ID로 유저 PK(userId) 조회
-        Long userId = usersRepository.findById(loginId)
-                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."))
-                .getUserId();
+            @AuthenticationPrincipal CustomUserDetails me)
+    throws Exception {
+        // 권한이 있을 때
+        if(me == null) return ResponseEntity.status(401).build();
 
         // 캘린더 데이터 조회
-        CalendarResponseDto response = calendarService.getCalendar(userId);
+        CalendarResponseDto response = calendarService.getCalendar(me.getId());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/quizley/controller/InsightRecordController.java
+++ b/src/main/java/com/example/quizley/controller/InsightRecordController.java
@@ -1,17 +1,17 @@
 package com.example.quizley.controller;
 
+import com.example.quizley.config.CustomUserDetails;
 import com.example.quizley.dto.calendar.CalendarResponseDto;
 import com.example.quizley.dto.insight.InsightRecordResponseDto;
-import com.example.quizley.service.InsightRecordService;
 import com.example.quizley.service.CalendarService;
-import com.example.quizley.config.jwt.JwtProvider;
-import com.example.quizley.repository.UsersRepository;
+import com.example.quizley.service.InsightRecordService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/insight/record")
@@ -20,57 +20,42 @@ public class InsightRecordController {
 
     private final InsightRecordService insightRecordService;
     private final CalendarService calendarService;
-    private final JwtProvider jwtProvider;
-    private final UsersRepository usersRepository;
 
-    // 선택한 날짜의 인사이트 조회
+    // 특정 날짜의 인사이트 목록 조회 (사용자가 실제로 푼 것만)
     @GetMapping("/{date}")
-    public ResponseEntity<InsightRecordResponseDto> getInsightByDate(
+    public ResponseEntity<?> getInsightByDate(
             @PathVariable LocalDate date,
-            HttpServletRequest request
+            @AuthenticationPrincipal CustomUserDetails me
     ) {
-        // JWT에서 로그인 ID 추출
-        String token = request.getHeader("Authorization");
-        if (token == null || !token.startsWith("Bearer ")) {
-            return ResponseEntity.status(401).build(); // 인증 실패
-        }
-
-        String jwt = token.replace("Bearer ", ""); // 실제 JWT 값만 분리
-        String loginId = jwtProvider.getSubject(jwt); // 토큰에서 로그인 ID 추출
-
-        // 로그인 ID로 유저 PK 조회
-        Long userId = usersRepository.findById(loginId)
-                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."))
-                .getUserId();
-
-        // 인사이트 조회
-        InsightRecordResponseDto response = insightRecordService.getInsightByDate(date);
-        return ResponseEntity.ok(response);
-    }
-
-    // 선택한 인사이트 삭제
-    @DeleteMapping("/{quizId}")
-    public ResponseEntity<CalendarResponseDto> deleteInsight(
-            @PathVariable Long quizId,
-            HttpServletRequest request
-    ) {
-        // JWT에서 로그인 ID 추출
-        String token = request.getHeader("Authorization");
-        if (token == null || !token.startsWith("Bearer ")) {
+        if (me == null) {
             return ResponseEntity.status(401).build();
         }
 
-        String jwt = token.replace("Bearer ", "");
-        String loginId = jwtProvider.getSubject(jwt);
+        Long userId = me.getId();
 
-        // 로그인 ID로 유저 PK 조회
-        Long userId = usersRepository.findById(loginId)
-                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."))
-                .getUserId();
+        List<InsightRecordResponseDto> insights =
+                insightRecordService.getInsightByDate(userId, date);
 
-        // 인사이트 삭제 + 캘린더 갱신
+        return ResponseEntity.ok(insights);
+    }
+
+    // 사용자가 푼 특정 인사이트 삭제
+    @DeleteMapping("/{quizId}")
+    public ResponseEntity<?> deleteInsight(
+            @PathVariable Long quizId,
+            @AuthenticationPrincipal CustomUserDetails me
+    ) {
+        if (me == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        Long userId = me.getId();
+
         insightRecordService.deleteInsight(quizId, userId);
-        CalendarResponseDto updatedCalendar = calendarService.getCalendar(userId);
-        return ResponseEntity.ok(updatedCalendar);
+
+        // 삭제 후 캘린더 다시 조회해서 반환
+        CalendarResponseDto calendar = calendarService.getCalendar(userId);
+
+        return ResponseEntity.ok(calendar);
     }
 }

--- a/src/main/java/com/example/quizley/controller/InsightRecordController.java
+++ b/src/main/java/com/example/quizley/controller/InsightRecordController.java
@@ -3,6 +3,8 @@ package com.example.quizley.controller;
 import com.example.quizley.config.CustomUserDetails;
 import com.example.quizley.dto.calendar.CalendarResponseDto;
 import com.example.quizley.dto.insight.InsightRecordResponseDto;
+import com.example.quizley.dto.insight.SameQuestionAnswerRequestDto;
+import com.example.quizley.dto.insight.SameQuestionAnswerResponseDto;
 import com.example.quizley.service.CalendarService;
 import com.example.quizley.service.InsightRecordService;
 import lombok.RequiredArgsConstructor;
@@ -57,5 +59,38 @@ public class InsightRecordController {
         CalendarResponseDto calendar = calendarService.getCalendar(userId);
 
         return ResponseEntity.ok(calendar);
+    }
+
+    // 같은 질문 과거 답변 목록 조회
+    @GetMapping("/{quizId}/answers")
+    public ResponseEntity<?> getSameQuestionAnswers(
+            @PathVariable Long quizId,
+            @AuthenticationPrincipal CustomUserDetails me
+    ) {
+        if (me == null) return ResponseEntity.status(401).build();
+
+        Long userId = me.getId();
+
+        List<SameQuestionAnswerResponseDto> answers =
+                insightRecordService.getSameQuestionAnswers(userId, quizId);
+
+        return ResponseEntity.ok(answers);
+    }
+
+    // 같은 질문 새 답변 등록
+    @PostMapping("/{quizId}/answers")
+    public ResponseEntity<?> addSameQuestionAnswer(
+            @PathVariable Long quizId,
+            @RequestBody SameQuestionAnswerRequestDto request,
+            @AuthenticationPrincipal CustomUserDetails me
+    ) {
+        if (me == null) return ResponseEntity.status(401).build();
+
+        Long userId = me.getId();
+
+        SameQuestionAnswerResponseDto saved =
+                insightRecordService.addSameQuestionAnswer(userId, quizId, request);
+
+        return ResponseEntity.ok(saved);
     }
 }

--- a/src/main/java/com/example/quizley/controller/ReportController.java
+++ b/src/main/java/com/example/quizley/controller/ReportController.java
@@ -1,0 +1,31 @@
+package com.example.quizley.controller;
+import com.example.quizley.config.CustomUserDetails;
+import com.example.quizley.dto.calendar.CalendarResponseDto;
+import com.example.quizley.dto.report.ReportResponseDto;
+import com.example.quizley.entity.users.Users;
+import com.example.quizley.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/report")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping("/summary")
+    public ResponseEntity<ReportResponseDto> getReport(
+            @AuthenticationPrincipal CustomUserDetails me) {
+        // 권한이 있을 때
+        if(me == null) return ResponseEntity.status(401).build();
+
+        // 리포트 생성
+        ReportResponseDto report = reportService.generateReport(me.getId());
+        return ResponseEntity.ok(report);
+    }
+}

--- a/src/main/java/com/example/quizley/dto/insight/SameQuestionAnswerRequestDto.java
+++ b/src/main/java/com/example/quizley/dto/insight/SameQuestionAnswerRequestDto.java
@@ -1,0 +1,9 @@
+package com.example.quizley.dto.insight;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class SameQuestionAnswerRequestDto {
+    private String answer;   // 사용자가 작성한 텍스트
+}

--- a/src/main/java/com/example/quizley/dto/insight/SameQuestionAnswerResponseDto.java
+++ b/src/main/java/com/example/quizley/dto/insight/SameQuestionAnswerResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.quizley.dto.insight;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SameQuestionAnswerResponseDto {
+
+    private Long answerId;          // balance_answer PK
+    private String answer;          // 텍스트 답변
+    private LocalDateTime createdAt; // 언제 쓴 답변인지
+}

--- a/src/main/java/com/example/quizley/dto/report/ReportResponseDto.java
+++ b/src/main/java/com/example/quizley/dto/report/ReportResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.quizley.dto.report;
+
+import lombok.*;
+import java.util.Map;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Builder
+public class ReportResponseDto {
+    private int streakDays; // 연속 답변일 수
+    private double topPercent; // 상위 몇 퍼센트인지
+    private String dominantCategory; // 가장 많이 참여한 카테고리명
+    private Map<String, Integer> scores; // 카테고리별 참여 횟수
+    private String feedback; // AI 피드백 (AI는 사용 안함)
+}

--- a/src/main/java/com/example/quizley/entity/insight/InsightAnswer.java
+++ b/src/main/java/com/example/quizley/entity/insight/InsightAnswer.java
@@ -1,0 +1,36 @@
+package com.example.quizley.entity.insight;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter
+@Table(name = "insight_answer")
+public class InsightAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "quiz_id", nullable = false)
+    private Long quizId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/example/quizley/repository/BalanceAnswerRepository.java
+++ b/src/main/java/com/example/quizley/repository/BalanceAnswerRepository.java
@@ -4,14 +4,19 @@ import com.example.quizley.entity.balance.BalanceAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface BalanceAnswerRepository extends JpaRepository<BalanceAnswer, Long> {
 
-    // 특정 퀴즈 + 유저 조합으로 응답 삭제
+    // 사용자가 특정 날짜에 푼 퀴즈 조회
+    List<BalanceAnswer> findByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    // 특정 퀴즈 + 유저의 답변 삭제
     void deleteByQuizIdAndUserId(Long quizId, Long userId);
 
     // 특정 퀴즈의 모든 투표 결과 조회
     List<BalanceAnswer> findByQuizId(Long quizId);
 }
+

--- a/src/main/java/com/example/quizley/repository/BalanceAnswerRepository.java
+++ b/src/main/java/com/example/quizley/repository/BalanceAnswerRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BalanceAnswerRepository extends JpaRepository<BalanceAnswer, Long> {
@@ -15,6 +16,12 @@ public interface BalanceAnswerRepository extends JpaRepository<BalanceAnswer, Lo
 
     // 특정 퀴즈 + 유저의 답변 삭제
     void deleteByQuizIdAndUserId(Long quizId, Long userId);
+
+    // 같은 질문에 다시 답해보기: 해당 유저가 이 퀴즈에 남긴 답변 히스토리
+    List<BalanceAnswer> findByUserIdAndQuizIdOrderByCreatedAtDesc(Long userId, Long quizId);
+
+    // 최신 기록(가장 마지막에 쓴 답변) – side 복사용
+    Optional<BalanceAnswer> findTop1ByUserIdAndQuizIdOrderByCreatedAtDesc(Long userId, Long quizId);
 
     // 특정 퀴즈의 모든 투표 결과 조회
     List<BalanceAnswer> findByQuizId(Long quizId);

--- a/src/main/java/com/example/quizley/repository/InsightAnswerRepository.java
+++ b/src/main/java/com/example/quizley/repository/InsightAnswerRepository.java
@@ -1,0 +1,12 @@
+package com.example.quizley.repository;
+
+import com.example.quizley.entity.insight.InsightAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InsightAnswerRepository extends JpaRepository<InsightAnswer, Long> {
+
+    // 같은 질문에 대한 해당 유저의 과거 답변 히스토리
+    List<InsightAnswer> findByUserIdAndQuizIdOrderByCreatedAtDesc(Long userId, Long quizId);
+}

--- a/src/main/java/com/example/quizley/repository/ReportRepository.java
+++ b/src/main/java/com/example/quizley/repository/ReportRepository.java
@@ -1,0 +1,70 @@
+package com.example.quizley.repository;
+
+import com.example.quizley.entity.quiz.AiChat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+public interface ReportRepository extends JpaRepository<AiChat, Long> {
+
+    // (이미 있던) 유저별 카테고리별 참여 횟수
+    @Query("SELECT c.quiz.category AS category, COUNT(c) AS cnt " +
+            "FROM AiChat c WHERE c.users.userId = :userId GROUP BY c.quiz.category")
+    List<Object[]> findCategoryStats(Long userId);
+
+    default Map<String, Integer> countByCategoryForUser(Long userId) {
+        return findCategoryStats(userId).stream()
+                .collect(Collectors.toMap(
+                        row -> row[0].toString(),
+                        row -> ((Number) row[1]).intValue()
+                ));
+    }
+
+    // 각 유저의 가장 최근에 끝난 연속 답변 일자를 current streak으로 리턴
+    @Query(value = """
+        WITH dates AS (
+          SELECT c.user_id, DATE(c.created_at) d
+          FROM comment c
+          GROUP BY c.user_id, DATE(c.created_at)
+        ),
+        seq AS (
+          SELECT user_id, d,
+                 LAG(d) OVER (PARTITION BY user_id ORDER BY d) AS prev_d
+          FROM dates
+        ),
+        grp AS (
+          SELECT user_id, d,
+                 CASE WHEN prev_d = DATE_SUB(d, INTERVAL 1 DAY) THEN 0 ELSE 1 END AS is_break
+          FROM seq
+        ),
+        grp2 AS (
+          SELECT user_id, d,
+                 SUM(is_break) OVER (PARTITION BY user_id ORDER BY d) AS g
+          FROM grp
+        ),
+        streaks AS (
+          SELECT user_id, g,
+                 COUNT(*) AS len,
+                 MAX(d)  AS end_d
+          FROM grp2
+          GROUP BY user_id, g
+        ),
+        current AS (
+          SELECT s.user_id, s.len
+          FROM streaks s
+          JOIN (
+            SELECT user_id, MAX(end_d) AS last_d
+            FROM streaks
+            GROUP BY user_id
+          ) t
+            ON s.user_id = t.user_id AND s.end_d = t.last_d
+        )
+        SELECT user_id, len FROM current
+        """, nativeQuery = true)
+    List<Object[]> findCurrentStreakAllUsers();
+}
+

--- a/src/main/java/com/example/quizley/service/InsightRecordService.java
+++ b/src/main/java/com/example/quizley/service/InsightRecordService.java
@@ -1,7 +1,7 @@
 package com.example.quizley.service;
 
-import com.example.quizley.domain.Origin;
 import com.example.quizley.dto.insight.InsightRecordResponseDto;
+import com.example.quizley.entity.balance.BalanceAnswer;
 import com.example.quizley.entity.quiz.Quiz;
 import com.example.quizley.repository.BalanceAnswerRepository;
 import com.example.quizley.repository.QuizRepository;
@@ -10,37 +10,54 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class InsightRecordService {
 
-    private final QuizRepository quizRepository;
     private final BalanceAnswerRepository balanceAnswerRepository;
+    private final QuizRepository quizRepository;
 
-    // 선택한 날짜의 인사이트 조회
-    public InsightRecordResponseDto getInsightByDate(LocalDate date) {
-        Quiz quiz = quizRepository.findByPublishedDateAndOrigin(date, Origin.SYSTEM)
-                .orElseThrow(() -> new IllegalArgumentException(date + " 날짜의 인사이트(퀴즈)를 찾을 수 없습니다."));
+    // 특정 날짜에 사용자가 실제로 푼 인사이트 조회
+    public List<InsightRecordResponseDto> getInsightByDate(Long userId, LocalDate date) {
 
-        return new InsightRecordResponseDto(
-                quiz.getQuizId(),
-                quiz.getCategory().name(),
-                quiz.getPublishedDate(),
-                quiz.getContent(),
-                null, // 요약 (팀원 기능 연동 시 추가)
-                null  // 피드백 (팀원 기능 연동 시 추가)
-        );
+        // 해당 날짜 00:00~23:59 범위 생성
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.atTime(23, 59, 59);
+
+        // 사용자가 해당 날짜에 푼 퀴즈 목록 조회
+        List<BalanceAnswer> answers =
+                balanceAnswerRepository.findByUserIdAndCreatedAtBetween(userId, start, end);
+
+        if (answers.isEmpty()) {
+            throw new IllegalArgumentException(date + " 날짜에 사용자가 푼 인사이트가 없습니다.");
+        }
+
+        // 각 answer마다 quiz 정보 조회 + DTO 변환
+        return answers.stream()
+                .map(answer -> {
+                    Quiz quiz = quizRepository.findById(answer.getQuizId())
+                            .orElseThrow(() -> new IllegalArgumentException("퀴즈 정보를 찾을 수 없습니다."));
+
+                    return new InsightRecordResponseDto(
+                            quiz.getQuizId(),
+                            quiz.getCategory().name(),
+                            quiz.getPublishedDate(),
+                            quiz.getContent(),
+                            null, // summary
+                            null  // feedback
+                    );
+                })
+                .toList();
     }
 
-    // 선택한 날짜의 인사이트 삭제 (응답 포함)
+    // 사용자가 푼 특정 인사이트 삭제
     @Transactional
     public void deleteInsight(Long quizId, Long userId) {
-        Quiz quiz = quizRepository.findById(quizId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 인사이트(퀴즈)를 찾을 수 없습니다."));
 
+        // 사용자가 푼 정답만 삭제 (퀴즈 자체는 삭제 X)
         balanceAnswerRepository.deleteByQuizIdAndUserId(quizId, userId);
-
-        quizRepository.delete(quiz);
     }
 }

--- a/src/main/java/com/example/quizley/service/ReportService.java
+++ b/src/main/java/com/example/quizley/service/ReportService.java
@@ -1,0 +1,162 @@
+package com.example.quizley.service;
+
+import com.example.quizley.dto.report.ReportResponseDto;
+import com.example.quizley.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private static final int MIN_COHORT = 30;
+    private final CalendarService calendarService;
+    private final ReportRepository reportRepository;
+
+    // 카테고리 한글 라벨 매핑
+    private static final Map<String, String> CATEGORY_LABELS = Map.of(
+            "PSYCHOLOGY", "심리학",
+            "SCIENCE", "자연과학",
+            "HISTORY", "역사",
+            "ART", "예술",
+            "LITERATURE", "문학",
+            "MYSTERY", "미스터리"
+    );
+
+    // 랜덤 메시지 세트
+    private static final List<String> STRONG_MESSAGES = List.of(
+            "%s 분야에서 정말 뛰어난 참여를 보여주고 있어요! 🔥",
+            "이번 달은 %s 분야 전문가 같아요! 멋져요 😊",
+            "%s 분야 문제에 특히 강한 모습을 보여주었어요!",
+            "꾸준함이 돋보여요! %s 분야에서 좋은 패턴이 보입니다."
+    );
+
+    private static final List<String> WEAK_MESSAGES = List.of(
+            "이번에는 %s 분야 문제도 도전해보지 않을래요? 😊",
+            "%s 분야를 풀면 더 균형 잡힌 실력을 만들 수 있을 거예요!",
+            "새로운 분야 %s 문제도 재미있게 풀어볼 수 있을 거예요!",
+            "%s 분야 문제도 시도해보면 더 성장할 수 있어요!"
+    );
+
+    public ReportResponseDto generateReport(Long userId) {
+
+        // streak 계산
+        var calendar = calendarService.getCalendar(userId);
+        int streakDays = calendar.getConsecutiveDays();
+
+        // 카테고리 응답 수 raw data
+        Map<String, Integer> rawScores = reportRepository.countByCategoryForUser(userId);
+
+        // 한글 라벨로 매핑
+        Map<String, Integer> labeledScores = convertLabels(rawScores);
+
+        // 레이더 차트 정규화 (0~100)
+        Map<String, Integer> normalizedScores = normalizeScores(labeledScores);
+
+        // dominant/least 계산 → 한글 라벨 기준
+        String dominant = findDominant(labeledScores);
+        String least = findLeast(labeledScores);
+
+        // 퍼센트 계산
+        double topPercent = computeTopPercentByCurrentStreak(userId, streakDays);
+
+        // 피드백 생성
+        String feedback = generateFeedback(dominant, least);
+
+        return ReportResponseDto.builder()
+                .streakDays(streakDays)
+                .topPercent(topPercent)
+                .dominantCategory(dominant)
+                .scores(normalizedScores)
+                .feedback(feedback)
+                .build();
+    }
+
+    //카테고리 한글 라벨 매핑
+    private Map<String, Integer> convertLabels(Map<String, Integer> raw) {
+        return raw.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> CATEGORY_LABELS.getOrDefault(e.getKey(), e.getKey()),
+                        Map.Entry::getValue
+                ));
+    }
+
+    // 0~100 정규화
+    private Map<String, Integer> normalizeScores(Map<String, Integer> scores) {
+        int max = scores.values().stream().max(Integer::compareTo).orElse(1);
+
+        return scores.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> (int) Math.round((e.getValue() * 100.0) / max)
+                ));
+    }
+
+    private String findDominant(Map<String, Integer> stats) {
+        return stats.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse("기타");
+    }
+
+    private String findLeast(Map<String, Integer> stats) {
+        return stats.entrySet().stream()
+                .min(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse("없음");
+    }
+
+    // 상위 퍼센트 계산
+    private double computeTopPercentByCurrentStreak(Long userId, int myCurrentStreak) {
+        var rows = reportRepository.findCurrentStreakAllUsers();
+        if (rows == null || rows.size() < MIN_COHORT) {
+            return estimateTopPercent(myCurrentStreak);
+        }
+
+        Map<Long, Integer> map = new HashMap<>();
+        for (Object[] r : rows) {
+            Long uid = ((Number) r[0]).longValue();
+            Integer len = ((Number) r[1]).intValue();
+            map.put(uid, len);
+        }
+
+        int my = map.getOrDefault(userId, 0);
+
+        long total = map.size();
+        long above = map.values().stream().filter(v -> v > my).count();
+        long equal = map.values().stream().filter(v -> v == my).count();
+
+        double top = 100.0 * (above + 0.5 * equal) / total;
+
+        top = Math.round(top);
+        return Math.max(1.0, Math.min(99.0, top));
+    }
+
+    private double estimateTopPercent(int streak) {
+        if (streak >= 10) return 10.0;
+        if (streak >= 7) return 30.0;
+        if (streak >= 5) return 50.0;
+        return 70.0;
+    }
+
+    // 피드백 생성
+    private String generateFeedback(String dominant, String least) {
+        String strong = random(STRONG_MESSAGES).formatted(dominant);
+
+        // least가 dominant와 같으면 분야가 편중된 경우 메시지 변경
+        if (least.equals(dominant)) {
+            return strong + " 다양한 분야 문제도 도전해보면 더 좋아요! 😊";
+        }
+
+        String weak = random(WEAK_MESSAGES).formatted(least);
+        return strong + " " + weak;
+    }
+
+    // 리스트에서 랜덤 메시지 하나 return
+    private String random(List<String> list) {
+        return list.get(new Random().nextInt(list.size()));
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
- 리포트 분석 및 분석 결과 반환(AI 피드백 포함)
- 인사이트 조회 페이지에서 같은 질문에 다시 답해보기 조회 기능 추가
- 같은 질문에 다시 답해보기 수정 기능 추가
---

## 🔗 포스트맨 이미지
리포트
<img width="1670" height="1156" alt="image" src="https://github.com/user-attachments/assets/b1df7025-ac79-4a9e-a357-3433da2fa8b3" />
인사이트 - 같은 질문에 다시 답해보기 조회
<img width="1692" height="1262" alt="image" src="https://github.com/user-attachments/assets/68f44118-cacc-436d-b11b-b6e5f5143c9e" />

인사이트 - 같은 질문에 다시 답해보기 수정
<img width="1686" height="1058" alt="image" src="https://github.com/user-attachments/assets/4597ebf7-9461-4713-86f9-6d2e47a38831" />
<img width="1680" height="1292" alt="image" src="https://github.com/user-attachments/assets/3fc546c2-f1eb-4790-8003-d29fd1462caa" />

---

## 📂 변경 사항
dto
ㄴinsight
   ㄴ InsightRecordResponseDto
   ㄴ SameQuestionAnswerRequestDto
   ㄴ SameQuestionAnswerResponseDto
repository
ㄴReportRepository
ㄴ InsightAnswerReporitory
controller
ㄴReportController
service
ㄴReportService

---

## 📝 비고
- 인사이트 조회(기록): 사용자가 답변한 퀴즈를 가져오도록 수정
- 같은 질문에 다시 답해보기 insight_answer 테이블 추가 (현재는 UNIQUE로 하나의 질문에 하나의 답변만 가능)