### PR TITLE
[FIX] 채팅 메시지 조회 방식 수정

### DIFF
--- a/src/main/java/com/example/quizley/service/QuizService.java
+++ b/src/main/java/com/example/quizley/service/QuizService.java
@@ -264,8 +264,11 @@ public class QuizService {
             page = 0;
         }
 
-        // 5) 실제 페이지 최신순 조회
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        // 5) 실제 페이지 최신순 조회, createdAt이 같다면 PK순으로
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt")
+                .and(Sort.by(Sort.Direction.DESC, "messageId")); // 엔티티 필드명이 id면 "id"로 바꿔!
+
+        Pageable pageable = PageRequest.of(page, size, sort);
         Page<AiMessage> messagePage = aiMessageRepository.findByChatChatId(chatId, pageable);
 
         // 현재 페이지 번호


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 채팅 메시지 조회 방식 수정

---

## 🔗 포스트맨 이미지
<img width="674" height="1080" alt="image" src="https://github.com/user-attachments/assets/973c90ef-bd13-4ccc-9dfd-ac3fd8629fc3" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- 동일한 createdAt을 가질 때 데이터 순서가 다르게 출력되는 문제가 생겼습니다. 동일한 createdAt을 가진다면 PK 순으로 정렬하여 반환하도록 수정했습니다.