### PR TITLE
[FIX] 사용자 차단 처리 및 오늘의 질문 답변 공개 여부

### DIFF
--- a/src/main/java/com/example/quizley/dto/community/QuizDetailDto.java
+++ b/src/main/java/com/example/quizley/dto/community/QuizDetailDto.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class QuizDetailDto {
     private Long quizId;
+    private Long userId;
     private String content;
     private String nickname; // 닉네임 또는 익명
     private Long likeCount;

--- a/src/main/java/com/example/quizley/dto/community/QuizListDto.java
+++ b/src/main/java/com/example/quizley/dto/community/QuizListDto.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class QuizListDto {
     private Long quizId;
+    private Long userId;
     private String content;
     private String category;
     private Long likeCount;
@@ -28,9 +29,10 @@ public class QuizListDto {
 
     //생성자
     public QuizListDto(Long quizId, String content, Category category, String nickname,
-                       long likeCount, long commentCount, LocalDateTime createdAt,
-                       LocalDate publishedDate, boolean isLiked, boolean isMine) {
+                       Long likeCount, Long commentCount, LocalDateTime createdAt,
+                       LocalDate publishedDate, Boolean isLiked, Boolean isMine, Long userId) {
         this.quizId = quizId;
+        this.userId = userId;
         this.content = content;
         this.category = category.name();
         this.nickname = (nickname != null) ? nickname : "익명";

--- a/src/main/java/com/example/quizley/repository/CommentRepository.java
+++ b/src/main/java/com/example/quizley/repository/CommentRepository.java
@@ -35,10 +35,11 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "LEFT JOIN Users u ON c.user.userId = u.userId " +
             "WHERE c.quiz.quizId = :quizId " +
             "AND c.deletedAt IS NULL " +
+            "AND c.commentAnonymous = com.example.quizley.domain.CommentAnonymous.OPEN " +
             "ORDER BY c.createdAt ASC")
     List<CommentDto> findCommentsByQuizId(@Param("quizId") Long quizId, @Param("userId") Long userId);
 
-    // ✅ 최신순 댓글 조회 (차단 필터링 포함)
+    // 최신순 댓글 조회 (차단 필터링 포함)
     @Query("SELECT new com.example.quizley.dto.community.CommentDto(" +
             "c.commentId, " +
             "c.user.userId, " +
@@ -60,6 +61,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "LEFT JOIN c.user u " +
             "WHERE c.quiz.quizId = :quizId " +
             "AND c.deletedAt IS NULL " +
+            "AND c.commentAnonymous = com.example.quizley.domain.CommentAnonymous.OPEN " +
             "AND (:userId IS NULL OR NOT EXISTS (" +
             "    SELECT 1 FROM BlockUser b " +
             "    WHERE b.blockerId = :userId AND b.blockedId = c.user.userId" +
@@ -71,7 +73,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "ORDER BY c.createdAt DESC")
     List<CommentDto> findCommentsByQuizIdOrderByLatest(@Param("quizId") Long quizId, @Param("userId") Long userId);
 
-    // ✅ 인기순 댓글 조회 (차단 필터링 포함)
+    // 인기순 댓글 조회 (차단 필터링 포함)
     @Query("SELECT new com.example.quizley.dto.community.CommentDto(" +
             "c.commentId, " +
             "c.user.userId, " +
@@ -93,6 +95,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "LEFT JOIN c.user u " +
             "WHERE c.quiz.quizId = :quizId " +
             "AND c.deletedAt IS NULL " +
+            "AND c.commentAnonymous = com.example.quizley.domain.CommentAnonymous.OPEN " +
             "AND (:userId IS NULL OR NOT EXISTS (" +
             "    SELECT 1 FROM BlockUser b " +
             "    WHERE b.blockerId = :userId AND b.blockedId = c.user.userId" +

--- a/src/main/java/com/example/quizley/repository/QuizRepository.java
+++ b/src/main/java/com/example/quizley/repository/QuizRepository.java
@@ -118,29 +118,30 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
 
     // 게시글 목록 조회(카테고리 필터링)
     @Query("SELECT new com.example.quizley.dto.community.QuizListDto(" +
-            "q.quizId, q.content, q.category, " +
+            "q.quizId, " +
+            "q.content, " +
+            "q.category, " +
             "CASE WHEN q.isAnonymous = true THEN '익명' ELSE u.nickname END, " +
-            "(SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId), " +
-
-            "(SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId AND c.deletedAt IS NULL), " +
-            "q.createdAt, q.publishedDate, " +
+            "CAST((SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId) AS long), " +
+            "CAST((SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId AND c.deletedAt IS NULL) AS long), " +
+            "q.createdAt, " +
+            "q.publishedDate, " +
             "(CASE WHEN :userId IS NULL THEN false " +
             "      WHEN EXISTS (SELECT 1 FROM QuizLike l2 WHERE l2.quiz.quizId = q.quizId AND l2.user.userId = :userId) THEN true " +
             "      ELSE false END), " +
             "(CASE WHEN :userId IS NULL THEN FALSE " +
             "      WHEN q.userId = :userId THEN TRUE " +
-            "      ELSE FALSE END)) " +
+            "      ELSE FALSE END), " +
+            "q.userId) " +
             "FROM Quiz q " +
             "LEFT JOIN Users u ON q.userId = u.userId " +
             "WHERE q.publishedDate = :date " +
             "AND q.origin = :origin " +
             "AND q.category = :category " +
-
             "AND (:userId IS NULL OR NOT EXISTS (" +
             "    SELECT 1 FROM BlockUser b " +
             "    WHERE b.blockerId = :userId AND b.blockedId = q.userId" +
             ")) " +
-
             "AND (:userId IS NULL OR NOT EXISTS (" +
             "    SELECT 1 FROM BlockUser b " +
             "    WHERE b.blockerId = q.userId AND b.blockedId = :userId" +
@@ -155,23 +156,25 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
 
     // 게시글 목록 조회(전체)
     @Query("SELECT new com.example.quizley.dto.community.QuizListDto(" +
-            "q.quizId, q.content, q.category, " +
+            "q.quizId, " +
+            "q.content, " +
+            "q.category, " +
             "CASE WHEN q.isAnonymous = true THEN '익명' ELSE u.nickname END, " +
-            "(SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId), " +
-
-            "(SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId AND c.deletedAt IS NULL), " +
-            "q.createdAt, q.publishedDate, " +
+            "CAST((SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId) AS long), " +
+            "CAST((SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId AND c.deletedAt IS NULL) AS long), " +
+            "q.createdAt, " +
+            "q.publishedDate, " +
             "(CASE WHEN :userId IS NULL THEN false " +
             "      WHEN EXISTS (SELECT 1 FROM QuizLike l2 WHERE l2.quiz.quizId = q.quizId AND l2.user.userId = :userId) THEN true " +
             "      ELSE false END), " +
             "(CASE WHEN :userId IS NULL THEN FALSE " +
             "      WHEN q.userId = :userId THEN TRUE " +
-            "      ELSE FALSE END)) " +
+            "      ELSE FALSE END), " +
+            "q.userId) " +
             "FROM Quiz q " +
             "LEFT JOIN Users u ON q.userId = u.userId " +
             "WHERE q.publishedDate = :date " +
             "AND q.origin = :origin " +
-
             "AND (:userId IS NULL OR NOT EXISTS (" +
             "    SELECT 1 FROM BlockUser b " +
             "    WHERE b.blockerId = :userId AND b.blockedId = q.userId" +
@@ -199,23 +202,25 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
 
     // 키워드로 퀴즈 검색 (최신순) - 차단 필터링 추가
     @Query("SELECT new com.example.quizley.dto.community.QuizListDto(" +
-            "q.quizId, q.content, q.category, " +
+            "q.quizId, " +
+            "q.content, " +
+            "q.category, " +
             "CASE WHEN q.isAnonymous = true THEN '익명' ELSE u.nickname END, " +
-            "(SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId), " +
-
-            "(SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId AND c.deletedAt IS NULL), " +
-            "q.createdAt, q.publishedDate, " +
+            "CAST((SELECT COUNT(l) FROM QuizLike l WHERE l.quiz.quizId = q.quizId) AS long), " +
+            "CAST((SELECT COUNT(c) FROM Comment c WHERE c.quiz.quizId = q.quizId AND c.deletedAt IS NULL) AS long), " +
+            "q.createdAt, " +
+            "q.publishedDate, " +
             "(CASE WHEN :userId IS NULL THEN false " +
             "      WHEN EXISTS (SELECT 1 FROM QuizLike l2 WHERE l2.quiz.quizId = q.quizId AND l2.user.userId = :userId) THEN true " +
             "      ELSE false END), " +
             "(CASE WHEN :userId IS NULL THEN FALSE " +
             "      WHEN q.userId = :userId THEN TRUE " +
-            "      ELSE FALSE END)) " +
+            "      ELSE FALSE END), " +
+            "q.userId) " +
             "FROM Quiz q " +
             "LEFT JOIN Users u ON q.userId = u.userId " +
             "WHERE q.content LIKE %:keyword% " +
             "AND q.origin = com.example.quizley.domain.Origin.USER " +
-
             "AND (:userId IS NULL OR NOT EXISTS (" +
             "    SELECT 1 FROM BlockUser b " +
             "    WHERE b.blockerId = :userId AND b.blockedId = q.userId" +

--- a/src/main/java/com/example/quizley/service/CommunityDetailService.java
+++ b/src/main/java/com/example/quizley/service/CommunityDetailService.java
@@ -69,6 +69,7 @@ public class CommunityDetailService {
 
         QuizDetailDto quizDetail = QuizDetailDto.builder()
                 .quizId(quiz.getQuizId())
+                .userId(quiz.getUserId())
                 .content(quiz.getContent())
                 .nickname(nickname)
                 .likeCount(likeCount)
@@ -78,7 +79,7 @@ public class CommunityDetailService {
                 .origin(quiz.getOrigin())
                 .canLike(quiz.getOrigin() == Origin.USER)
                 .canComment(quiz.getOrigin() == Origin.USER)
-                .isMine(isMine)  // ✅ userId 기준
+                .isMine(isMine)
                 .build();
 
         List<CommentDto> comments = getCommentsWithTimeFormat(quizId, currentUserId, sort);

--- a/src/main/java/com/example/quizley/service/QuizService.java
+++ b/src/main/java/com/example/quizley/service/QuizService.java
@@ -222,6 +222,18 @@ public class QuizService {
 
         Long chatId = aiChatRepository.save(aiChat).getChatId();
 
+        //Comment
+        Comment comment = new Comment();
+        comment.setUser(user);
+        comment.setQuiz(quiz);
+        comment.setContent("");
+        comment.setStatus(Status.PROGRESS);
+        comment.setCommentAnonymous(CommentAnonymous.CLOSE); // 디폴트 비공개
+        comment.setWriterAnonymous(false);
+        comment.setLikeCount(0);
+
+        commentRepository.save(comment);
+
         if (form.getContent() != null && !form.getContent().isBlank()) {
             // 채팅 메시지 전송
             chatService.chat(chatId, userId, form.getContent());


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 사용자 차단 처리 확인
- 오늘의 질문 답변 공개 여부 수정

---

## 🔗 포스트맨 이미지

오늘의 질문 답변 공개 여부
<img width="775" height="335" alt="스크린샷 2025-12-02 오전 12 21 25" src="https://github.com/user-attachments/assets/134f1e2e-fbdd-43ca-a521-ec4fdf708179" />
기존

<img width="775" height="487" alt="스크린샷 2025-12-02 오전 12 21 32" src="https://github.com/user-attachments/assets/fbc36056-3a6b-4b9d-aabc-4f9c534a7967" />
수정 후 비공개 상태

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 📝 비고
<!-- 추가로 전달할 사항 -->