### PR TITLE
[FIX] 오늘의 퀴즈 댓글 에러 해결

### DIFF
--- a/src/main/java/com/example/quizley/service/ChatService.java
+++ b/src/main/java/com/example/quizley/service/ChatService.java
@@ -328,7 +328,7 @@ public class ChatService {
                                 c.setQuiz(quiz);
 
                                 // 사용자의 "최종 답변"으로 ai 요약본 삽입
-                                c.setContent(mergedSummary);
+                                //c.setContent(mergedSummary);
 
                                 c.setStatus(Status.PROGRESS);                     // 답변 완료 상태로 가정
                                 c.setCommentAnonymous(CommentAnonymous.CLOSE); // 등록 전에는 비공개
@@ -337,10 +337,10 @@ public class ChatService {
 
                                 return c;
                             });
-
-                    // 새로 만들었든 기존이든, feedback은 여기서 세팅
-                    comment.setFeedback(feedback);
-                    commentRepository.save(comment);
+            comment.setContent(mergedSummary);
+            // 새로 만들었든 기존이든, feedback은 여기서 세팅
+            comment.setFeedback(feedback);
+            commentRepository.save(comment);
 
             // 5) 채팅방 상태를 CLOSED 로 변경
             chat.close();


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->

- 오늘의 퀴즈 인사이트가 댓글 처리가 안되는 문제 해결

---

## 🔗 포스트맨 이미지

메시지 전송
<img width="825" height="736" alt="스크린샷 2025-12-02 오후 5 11 01" src="https://github.com/user-attachments/assets/dd8ffdca-2427-4b35-906d-6a0c3aeb3f32" />

최종 요약 및 피드백 생성
<img width="825" height="736" alt="스크린샷 2025-12-02 오후 5 11 06" src="https://github.com/user-attachments/assets/555d126a-3719-4b37-8230-5ecf1b657a2a" />

답변 완료 처리
<img width="825" height="736" alt="스크린샷 2025-12-02 오후 5 11 11" src="https://github.com/user-attachments/assets/e9169555-10a8-403f-b72f-c3b5ac88c1b6" />

댓글 (공개 설정 안했을 때 디폴트값으로 설정)
<img width="825" height="825" alt="스크린샷 2025-12-02 오후 5 11 22" src="https://github.com/user-attachments/assets/3483f957-23c0-46b1-9f8a-a2faddf29442" />

(답변 공개 및 최종 확인 후) 댓글 공개로 설정했을 때
<img width="825" height="825" alt="스크린샷 2025-12-02 오후 5 12 56" src="https://github.com/user-attachments/assets/a6101320-4a2f-4403-8194-db958103f33d" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- ChatService 일부 수정하였습니다.