### PR TITLE
[FIX] 게시글 생성 날짜 응답 수정

### DIFF
--- a/src/main/java/com/example/quizley/service/CommunityDetailService.java
+++ b/src/main/java/com/example/quizley/service/CommunityDetailService.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import java.time.ZoneId;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -284,7 +285,7 @@ public class CommunityDetailService {
                 .category(dto.getCategory())
                 .userId(userId)
                 .isAnonymous(isAnonymous)
-                .publishedDate(LocalDate.now())
+                .publishedDate(LocalDate.now(ZoneId.of("Asia/Seoul")))
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
                 .build();


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->

-  게시글 생성 날짜 응답 수정

---

## 🔗 포스트맨 이미지

12월 4일에 만든 질문이 4일 조회에 보이는 모습
<img width="807" height="892" alt="스크린샷 2025-12-04 오전 1 24 39" src="https://github.com/user-attachments/assets/1404abb2-df3e-4f24-8c85-6c8bf8c72da9" />

3일 조회에에는 4일에 만든 글이 보이지 않음
<img width="807" height="892" alt="스크린샷 2025-12-04 오전 1 25 29" src="https://github.com/user-attachments/assets/6c180fe6-3cac-48c3-add5-e809305d2fb7" />


---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 📝 비고
<!-- 추가로 전달할 사항 -->